### PR TITLE
Remove the dangling collection .loadingMore state

### DIFF
--- a/UI/Source/CollectionViews/mac/CollectionViewController.swift
+++ b/UI/Source/CollectionViews/mac/CollectionViewController.swift
@@ -425,8 +425,6 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
                 if models == nil {
                     showLoadingView()
                 }
-            case .loadingMore:
-                break
             case .loaded:
                 updateEmptyContentViewVisibility()
             case .error(_):
@@ -472,7 +470,7 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
             } else {
                 hideEmptyContentView()
             }
-        case .notLoaded, .loading, .loadingMore:
+        case .notLoaded, .loading:
             hideEmptyContentView()
         }
     }


### PR DESCRIPTION
PilotUI for macOS currently cannot build, as dangling references to `.loadingMore` have been left in the source. This PR fixes this.