### PR TITLE
Removing stale reference to previous project name

### DIFF
--- a/Pilot.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Pilot.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:BoxKit.xcodeproj">
+      location = "self:Pilot.xcodeproj">
    </FileRef>
 </Workspace>


### PR DESCRIPTION
Noticed something interesting in Xcode while working on something else 😆 🗃 

<img width="665" alt="screen shot 2017-02-24 at 1 34 09 am" src="https://cloud.githubusercontent.com/assets/3551/23298445/9ebc32bc-fa32-11e6-91b9-8fc1182f8201.png">
