### PR TITLE
Allow view model actions/cv delegates to swallow keyboard events

### DIFF
--- a/UI/Source/CollectionViews/mac/CollectionView.swift
+++ b/UI/Source/CollectionViews/mac/CollectionView.swift
@@ -52,6 +52,8 @@ public final class CollectionView: NSCollectionView {
         case .upArrow, .downArrow:
             let oldSelectionIndexPaths = selectionIndexPaths
 
+            // TODO:(danielh) investigate whether this should have an else that forwards events while skipping super's
+            // selection behavior.
             if !keyboardSelectionDisabled {
                 super.keyDown(with: event)
             }

--- a/UI/Source/CollectionViews/mac/CollectionViewController.swift
+++ b/UI/Source/CollectionViews/mac/CollectionViewController.swift
@@ -218,22 +218,26 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
 
     // MARK: CollectionViewDelegate
 
-    open func collectionViewDidReceiveReturnKey(_ collectionView: NSCollectionView) {
+    open func collectionViewDidReceiveReturnKey(_ collectionView: NSCollectionView) -> Bool {
         // Right now, only a single selected item is supported for the return/enter keys.
-        guard let indexPath = collectionView.selectionIndexPaths.first else { return }
-        guard let vm = viewModelAtIndexPath(indexPath) else { return }
+        guard let indexPath = collectionView.selectionIndexPaths.first else { return false }
+        guard let vm = viewModelAtIndexPath(indexPath) else { return false }
         if vm.canHandleUserEvent(.enterKey) {
             vm.handleUserEvent(.enterKey)
+            return true
         }
+        return false
     }
 
-    open func collectionViewDidReceiveSpaceKey(_ collectionView: NSCollectionView) {
+    open func collectionViewDidReceiveSpaceKey(_ collectionView: NSCollectionView) -> Bool {
         // Right now, only a single selected item is supported for the space keys.
-        guard let indexPath = collectionView.selectionIndexPaths.first else { return }
-        guard let vm = viewModelAtIndexPath(indexPath) else { return }
+        guard let indexPath = collectionView.selectionIndexPaths.first else { return false }
+        guard let vm = viewModelAtIndexPath(indexPath) else { return false }
         if vm.canHandleUserEvent(.spaceKey) {
             vm.handleUserEvent(.spaceKey)
+            return true
         }
+        return false
     }
 
     open func collectionView(_ collectionView: NSCollectionView, didClickIndexPath indexPath: IndexPath) {


### PR DESCRIPTION
Currently if you perform a view model action on enter/space since `super.keyDown(with:)` was always getting called in the collection view's `keyDown` function it would always result in the event passing further up the responder chain (usually resulting in the error/alert sound playing if nothing else handled the event).
