### PR TITLE
Delay applying new state to currentCollection

### DIFF
--- a/UI/Source/CollectionViews/CollectionViewModelDataSource.swift
+++ b/UI/Source/CollectionViews/CollectionViewModelDataSource.swift
@@ -57,11 +57,9 @@ public final class CurrentCollection: ModelCollection, ProxyingCollectionEventOb
     // MARK: Private
 
     fileprivate func beginUpdate(_ collection: ModelCollection) -> (CollectionEventUpdates, () -> Void){
-        state = collection.state
-
         let updates = diffEngine.update(collection.sections, debug: false)
         return (updates, {
-            self.currentSections = collection.state.sections
+            self.state = collection.state
         })
     }
 
@@ -71,7 +69,6 @@ public final class CurrentCollection: ModelCollection, ProxyingCollectionEventOb
     }
 
     private var diffEngine = DiffEngine()
-    private var currentSections: [[Model]] = []
 }
 
 /// Data source for collection views which handles all the necessary binding between models -> view models, and view


### PR DESCRIPTION
Since state was being immediately applied to CollectionViewModelDataSource's currentCollection it would result in observers of CollectionViewModelDataSource to get the post-update sections if they queried during `.willUpdateItems`, this is a pretty bad breach of that api contract but thankfully diff endine has its own copy of the sections so wasn't effected.