### PR TITLE
Two fixes for loading state.

### DIFF
--- a/Core/Source/MVVM/ModelCollection.swift
+++ b/Core/Source/MVVM/ModelCollection.swift
@@ -25,16 +25,6 @@ public enum ModelCollectionState {
             return models
         }
     }
-
-    public var isNotLoaded: Bool {
-        if case .notLoaded = self { return true }
-        return false
-    }
-
-    public var isLoading: Bool {
-        if case .loading = self { return true }
-        return false
-    }
 }
 
 /// Event types sent to `CollectionEventObserver` types.
@@ -198,6 +188,41 @@ public func generateModelIdToIndexPathMapForSections(_ sections: [[Model]]) -> [
         sectionIndex += 1
     }
     return map
+}
+
+extension ModelCollectionState {
+    public var isNotLoaded: Bool {
+        if case .notLoaded = self { return true }
+        return false
+    }
+
+    public var isLoading: Bool {
+        if case .loading = self { return true }
+        return false
+    }
+
+    public var isLoaded: Bool {
+        if case .loaded = self { return true }
+        return false
+    }
+
+    public var isEmpty: Bool {
+        switch self {
+        case .notLoaded, .error:
+            return true
+        case .loading(let models):
+            guard let models = models else { return true }
+            for section in models {
+                if !section.isEmpty { return false }
+            }
+            return true
+        case .loaded(let models):
+            for section in models {
+                if !section.isEmpty { return false }
+            }
+            return true
+        }
+    }
 }
 
 extension ModelCollection {

--- a/UI/Source/CollectionViews/CollectionViewModelDataSource.swift
+++ b/UI/Source/CollectionViews/CollectionViewModelDataSource.swift
@@ -58,8 +58,9 @@ public final class CurrentCollection: ModelCollection, ProxyingCollectionEventOb
 
     fileprivate func beginUpdate(_ collection: ModelCollection) -> (CollectionEventUpdates, () -> Void){
         let updates = diffEngine.update(collection.sections, debug: false)
+        let commitState = collection.state
         return (updates, {
-            self.state = collection.state
+            self.state = commitState
         })
     }
 

--- a/UI/Source/CollectionViews/ios/CollectionViewController.swift
+++ b/UI/Source/CollectionViews/ios/CollectionViewController.swift
@@ -246,8 +246,8 @@ open class CollectionViewController: UIViewController, UICollectionViewDelegate 
             switch state {
             case .notLoaded:
                 break
-            case .loading(let sections):
-                if sections == nil {
+            case .loading(let models):
+                if models == nil || state.isEmpty {
                     showSpinner()
                 }
             case .loaded:
@@ -257,7 +257,6 @@ open class CollectionViewController: UIViewController, UICollectionViewDelegate 
             }
         }
     }
-
 
     /// Spinner to show when in the `Loading` state.
     fileprivate var spinner: UIActivityIndicatorView?

--- a/UI/Source/CollectionViews/mac/CollectionViewController.swift
+++ b/UI/Source/CollectionViews/mac/CollectionViewController.swift
@@ -426,7 +426,7 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
             case .notLoaded:
                 break
             case .loading(let models):
-                if models == nil {
+                if models == nil || state.isEmpty {
                     showLoadingView()
                 }
             case .loaded:


### PR DESCRIPTION
• Ensure spinner is shown for empty (but non-nil) loading states.
• Fix potential race condition with update state commits.