### PR TITLE
Fix CollectionView state transitions w/o updates.

### DIFF
--- a/Core/Source/MVVM/ModelCollection.swift
+++ b/Core/Source/MVVM/ModelCollection.swift
@@ -15,6 +15,7 @@ public enum ModelCollectionState {
     /// The model collection encountered an error loading data.
     case error(Error)
 
+    /// Unpacks and returns any associated model sections.
     public var sections: [[Model]] {
         switch self {
         case .notLoaded, .error:
@@ -23,6 +24,20 @@ public enum ModelCollectionState {
             return models ?? []
         case .loaded(let models):
             return models
+        }
+    }
+
+    /// Returns whether or not the underlying enum case is different than the target. Ignores associated model
+    /// objects.
+    public func isDifferentCase(than other: ModelCollectionState) -> Bool {
+        switch (self, other) {
+        case (.notLoaded, .notLoaded),
+             (.loading(_), .loading(_)),
+             (.loaded(_), .loaded(_)),
+             (.error(_), .error(_)):
+            return false
+        default:
+            return true
         }
     }
 }

--- a/UI/Source/CollectionViews/CollectionViewModelDataSource.swift
+++ b/UI/Source/CollectionViews/CollectionViewModelDataSource.swift
@@ -459,8 +459,12 @@ public class CollectionViewModelDataSource: NSObject, ProxyingObservable {
 
         let (updates, commitCollectionChanges) = currentCollection.beginUpdate(underlyingCollection)
         guard updates.hasUpdates else {
-            // still synced
-            // no need to update lastKnownCollectionViewContents
+            // Still synced - no need to fire a collection view update pass.
+            // However, if there are no updates, the underlying case may still change (e.g. .loading(_) -> .error(_)),
+            // so a commit is still needed.
+            if underlyingCollection.state.isDifferentCase(than: currentCollection.state) {
+                commitCollectionChanges()
+            }
             return
         }
 


### PR DESCRIPTION
• State transitions in the collection view model data source that didn't have item updates
  were being dropped, causing certain state changes to not take effect (e.g. `.notLoaded` -> `.loading(nil)`)
• This change ensures those state transitions are committed.
Fixes https://github.com/dropbox/pilot/issues/22