### PR TITLE
Fix collection view crash during animations.

### DIFF
--- a/UI/Source/CollectionViews/mac/CollectionViewController.swift
+++ b/UI/Source/CollectionViews/mac/CollectionViewController.swift
@@ -279,6 +279,15 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
 
     open func collectionView(
         _ collectionView: NSCollectionView,
+        didEndDisplaying item: NSCollectionViewItem,
+        forRepresentedObjectAt indexPath: IndexPath
+    ) {
+        // Intentionally a noop - implemented as an extra safeguard against an internal nscollectionview crash during
+        // animations where the collection view is deallocated before completion.
+    }
+
+    open func collectionView(
+        _ collectionView: NSCollectionView,
         didSelectItemsAt indexPaths: Set<IndexPath>
     ) {
         guard let indexPath = indexPaths.first , indexPaths.count == 1 else { return }


### PR DESCRIPTION
• If a collection view (and the associated delegate/view controller) is deallocated during an performBatchUpdates
operation, collection view internals will still call the non-zeroing weak delegate after it's gone. Protect against
this case.

Typical callstack would be:
```
Selector name found in current argument registers: collectionView:didEndDisplayingItem:forRepresentedObjectAtIndexPath:

Thread 0 Crashed:
0   libobjc.A.dylib                      0x00007fff9f7674dd objc_msgSend + 29
1   UIFoundation                         0x00007fff9a4eae76 -[_NSCollectionViewCore _reuseCell:] + 413
2   UIFoundation                         0x00007fff9a4f1227 -[_NSCollectionViewCore _updateAnimationDidStop:finished:context:] + 973
3   libdispatch.dylib                    0x00007fff9c6bb93d _dispatch_call_block_and_release + 11
4   libdispatch.dylib                    0x00007fff9c6b040b _dispatch_client_callout + 7
5   libdispatch.dylib                    0x00007fff9c6c3c1c _dispatch_main_queue_callback_4CF + 1684
6   CoreFoundation                       0x00007fff961a1949 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 8
7   CoreFoundation                       0x00007fff9616083d __CFRunLoopRun + 1948
8   CoreFoundation                       0x00007fff9615fe38 CFRunLoopRunSpecific + 295
9   HIToolbox                            0x00007fff8c2b6935 RunCurrentEventLoopInMode + 234
10  HIToolbox                            0x00007fff8c2b676f ReceiveNextEventCommon + 431
11  HIToolbox                            0x00007fff8c2b65af _BlockUntilNextEventMatchingListInModeWithFilter + 70
12  AppKit                               0x00007fff927b2df6 _DPSNextEvent + 1066
13  AppKit                               0x00007fff927b2226 -[NSApplication _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 453
14  AppKit                               0x00007fff927a6d80 -[NSApplication run] + 681
15  AppKit                               0x00007fff92770368 NSApplicationMain + 1175
16  [App]                                0x0000000108238bda main (main.swift:18)
17  libdyld.dylib                        0x00007fff9a8c85ad start + 1
```