### PR TITLE
Fix misannotated swift API usage.

### DIFF
--- a/UI/Source/CollectionViews/mac/CollectionViewController.swift
+++ b/UI/Source/CollectionViews/mac/CollectionViewController.swift
@@ -279,15 +279,6 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
 
     open func collectionView(
         _ collectionView: NSCollectionView,
-        didEndDisplaying item: NSCollectionViewItem,
-        forRepresentedObjectAt indexPath: IndexPath
-    ) {
-        // Intentionally a noop - implemented as an extra safeguard against an internal nscollectionview crash during
-        // animations where the collection view is deallocated before completion.
-    }
-
-    open func collectionView(
-        _ collectionView: NSCollectionView,
         didSelectItemsAt indexPaths: Set<IndexPath>
     ) {
         guard let indexPath = indexPaths.first , indexPaths.count == 1 else { return }


### PR DESCRIPTION
• Leads to crashes on release builds during retain/release w/ garbage values (see https://bugs.swift.org/browse/SR-2417)
• In this case, IndexPath is optional - but it's not used so can revert the delegate implementation.