### PR TITLE
Add support for View factory in ViewBinding

### DIFF
--- a/Core/Source/MVVM/View.swift
+++ b/Core/Source/MVVM/View.swift
@@ -53,11 +53,13 @@ public protocol View: class {
     var highlightStyle: ViewHighlightStyle { get set }
 }
 
-/// Represents the binding from a ViewModel to a View.
+/// Represents the binding from a ViewModel to a View. By default will automatically create the View instance for you
+/// or alternativly a custom closure can be provided to intialize the view. This is useful if the view takes
+/// additional arguments on init.
 public struct ViewBinding {
-    public init<T: View>(_ viewType: T.Type) {
+    public init<T: View>(_ viewType: T.Type, make: @escaping () -> T = { return T() }) {
         self.viewType = viewType
-        generate = { $0 as? T ?? viewType.init() }
+        self.generate = { $0 as? T ?? make() }
     }
 
     public let viewType: View.Type


### PR DESCRIPTION
This makes it possible to provide a custom View initializer without having to create an entire `ViewBindingProvider`. This is useful if the view requires extra initialisation arguments.

```swift
let provider =  BlockViewBindingProvider { (vm, _) -> ViewBinding? in
  switch vm {
  case is MyModel :
    return ViewBinding(MyView.self) {  MyView(foo: foo, bar: bar, baz: baz) }
  default: return nil
}
``` 