### PR TITLE
Add context arg to View.preferredLayout

### DIFF
--- a/Core/Source/MVVM/View.swift
+++ b/Core/Source/MVVM/View.swift
@@ -58,11 +58,13 @@ public protocol View: class {
     var highlightStyle: ViewHighlightStyle { get set }
 }
 
-/// Represents the binding from a ViewModel to a View.
+/// Represents the binding from a ViewModel to a View. By default will automatically create the View instance for you
+/// or alternativly a custom closure can be provided to intialize the view. This is useful if the view takes
+/// additional arguments on init.
 public struct ViewBinding {
-    public init<T: View>(_ viewType: T.Type) {
+    public init<T: View>(_ viewType: T.Type, make: @escaping () -> T = { return T() }) {
         self.viewType = viewType
-        generate = { $0 as? T ?? viewType.init() }
+        self.generate = { $0 as? T ?? make() }
     }
 
     public let viewType: View.Type

--- a/Core/Source/MVVM/View.swift
+++ b/Core/Source/MVVM/View.swift
@@ -27,14 +27,19 @@ public protocol View: class {
     /// `viewModel` back to `nil`.
     func unbindFromViewModel()
 
-    /// Invoked by view binding systems before the view will be laid out with the given available size.
-    func willLayoutWithAvailableSize(_ availableSize: AvailableSize)
+    /// Invoked by view binding systems before the view will be laid out with the given available size. The `object`
+    /// argument allows the caller to provide any context to the view that may affect its layout. For example it's
+    /// position in a collection view, or information about the preceding view.
+    func willLayoutWithAvailableSize(_ availableSize: AvailableSize, with object: Any?)
 
     /// Returns the preferred layout for the given `viewModel` if rendered by this `View`. This is a static method
-    /// for optimized performance so view size estimation does not require an actual bound instance of a view.
+    /// for optimized performance so view size estimation does not require an actual bound instance of a view. The 
+    /// `object` argument allows the caller to provide any context to the view that may affect its layout. For
+    /// example it's position in a collection view, or information about the preceding view.
     static func preferredLayout(
         fitting availableSize: AvailableSize,
-        for viewModel: ViewModel
+        for viewModel: ViewModel,
+        with object: Any?
     ) -> PreferredLayout
 
     /// Applies the given `ViewLayout` to the target view type. This is the same `ViewLayout` object as returned by
@@ -129,7 +134,7 @@ public extension ViewBindingProvider {
         context: Context
     ) -> PreferredLayout {
         let viewType = viewTypeForViewModel(viewModel, context: context)
-        return viewType.preferredLayout(fitting: availableSize, for: viewModel)
+        return viewType.preferredLayout(fitting: availableSize, for: viewModel, with: context)
     }
 }
 
@@ -241,13 +246,14 @@ public struct AvailableSize {
 /// that they may not need.
 public extension View {
 
-    public func willLayoutWithAvailableSize(_ availableSize: AvailableSize) { }
+    public func willLayoutWithAvailableSize(_ availableSize: AvailableSize, with object: Any? = nil) { }
 
     public func applyLayout(_ layout: ViewLayout) {}
 
     public static func preferredLayout(
         fitting availableSize: AvailableSize,
-        for viewModel: ViewModel
+        for viewModel: ViewModel,
+        with object: Any? = nil
     ) -> PreferredLayout {
         return .none
     }

--- a/Core/Source/MVVM/View.swift
+++ b/Core/Source/MVVM/View.swift
@@ -248,14 +248,14 @@ public struct AvailableSize {
 /// that they may not need.
 public extension View {
 
-    public func willLayoutWithAvailableSize(_ availableSize: AvailableSize, with object: Any? = nil) { }
+    public func willLayoutWithAvailableSize(_ availableSize: AvailableSize, with object: Any?) { }
 
     public func applyLayout(_ layout: ViewLayout) {}
 
     public static func preferredLayout(
         fitting availableSize: AvailableSize,
         for viewModel: ViewModel,
-        with object: Any? = nil
+        with object: Any?
     ) -> PreferredLayout {
         return .none
     }


### PR DESCRIPTION
This allows the ViewBindingProvider and other callers to pass in additional context to the view that may affect layout. The extension implementations have been updated to default this value to nil.

Example:

```swift
static func preferredLayout(
    fitting availableSize: AvailableSize,
    for viewModel: ViewModel,
    with object: Any?
) -> PreferredLayout {
    let position: CellPosition = object as? CellPosition ?? .top
    return position == .top ? layoutForTop() : defaultLayoutForView()
}
```