### PR TITLE
Have host view always re-apply attributes

### DIFF
--- a/UI/Source/CollectionViews/CollectionViewModelDataSource.swift
+++ b/UI/Source/CollectionViews/CollectionViewModelDataSource.swift
@@ -665,11 +665,6 @@ extension CollectionViewModelDataSource: UICollectionViewDataSource {
 
         willRebindViewModel(viewModel)
         cell.hostedView?.bindToViewModel(viewModel)
-
-        // When rebinding, re-apply attributes so that the updated ViewModel is notified.
-        if let attributes = collectionView.layoutAttributesForItem(at: indexPath) {
-            cell.apply(attributes)
-        }
     }
 
     // MARK: UICollectionViewDataSource
@@ -1062,15 +1057,10 @@ extension CollectionViewModelDataSource: NSCollectionViewDataSource {
 
     private func rebindViewAtIndexPath(_ indexPath: IndexPath, toViewModel viewModel: ViewModel) {
         guard let collectionView = collectionView else { return }
-        guard let item = collectionView.item(at: indexPath) as? CollectionViewHostItem else { return }
+        guard let item = collectionView.item(at: indexPath as IndexPath) as? CollectionViewHostItem else { return }
 
         willRebindViewModel(viewModel)
         item.hostedView?.bindToViewModel(viewModel)
-
-        // When rebinding, re-apply attributes so that the updated ViewModel is notified.
-        if let attributes = collectionView.layoutAttributesForItem(at: indexPath) {
-            item.apply(attributes)
-        }
     }
 
     private func shouldFakeMoves(updates: CollectionEventUpdates) -> Bool {

--- a/UI/Source/CollectionViews/ios/CollectionViewHostReusableView.swift
+++ b/UI/Source/CollectionViews/ios/CollectionViewHostReusableView.swift
@@ -42,12 +42,6 @@ internal final class CollectionViewHostResuableView: UICollectionReusableView {
 
     // MARK: UICollectionReusableView
 
-    internal override func prepareForReuse() {
-        super.prepareForReuse()
-
-        cachedLayoutAttributes = nil
-    }
-
     internal override func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
         super.apply(layoutAttributes)
 

--- a/UI/Source/CollectionViews/mac/CollectionViewHostItem.swift
+++ b/UI/Source/CollectionViews/mac/CollectionViewHostItem.swift
@@ -56,7 +56,6 @@ public final class CollectionViewHostItem: NSCollectionViewItem {
         super.prepareForReuse()
 
         menuTrackingCookie += 1
-        cachedLayoutAttributes = nil
         highlightStyle = .none
 
         if let cvt = hostedView as? CollectionSupportingView {


### PR DESCRIPTION
Need to keep copy of layout attributes to apply to a new "hostView" in the case that the collection view re-uses the host view/cell with the same attributes so that they can be re-applied to the new  `hostedView`