### PR TITLE
Disable drawing scroller tracks.

### DIFF
--- a/UI/Source/CollectionViews/mac/CollectionViewController.swift
+++ b/UI/Source/CollectionViews/mac/CollectionViewController.swift
@@ -533,6 +533,14 @@ private final class FullWidthScroller: NSScroller {
         return true
     }
 
+    override class func preferredScrollerStyle() -> NSScrollerStyle {
+        return .overlay
+    }
+
+    override func drawKnobSlot(in slotRect: NSRect, highlight flag: Bool) {
+        // Nop
+    }
+
     override class func scrollerWidth(
         for controlSize: NSControlSize,
         scrollerStyle: NSScrollerStyle


### PR DESCRIPTION
• `CollectionViewController` is a full-width view and doesn't support tracks when the system
`NSScrollerStyle` is `.legacy`.