### PR TITLE
RFC: Simple Analytics Event API

### DIFF
--- a/Core/Source/MVVM/Action.swift
+++ b/Core/Source/MVVM/Action.swift
@@ -24,7 +24,14 @@ public extension Action {
     /// ```
     @discardableResult
     func send(from sender: ActionSender) -> ActionResult {
-        return sender.send(self)
+        // TODO:(danielh) add comment here explaining why this has to be here
+        if let wrappedAction = self as? AnalyticsEventWrappedAction {
+            let res = sender.send(self)
+            _ = SendAnalyticsEventAction(event: wrappedAction.event)
+            return res
+        } else {
+            return sender.send(self)
+        }
     }
 }
 

--- a/Core/Source/MVVM/Analytics.swift
+++ b/Core/Source/MVVM/Analytics.swift
@@ -1,0 +1,31 @@
+public protocol AnalyticsEvent {
+    var name: String { get }
+    var properties: [String: Any] { get }
+}
+
+public enum AnalyticsPropertyValueType {
+    case bool(Bool)
+    case string(String)
+    case int(Int)
+    case float(Float)
+    case array([AnalyticsPropertyValueType])
+    case map([String: AnalyticsPropertyValueType])
+}
+
+public struct SendAnalyticsEventAction: Action {
+    public init(event: AnalyticsEvent) {
+        self.event = event
+    }
+
+    public var event: AnalyticsEvent
+}
+
+public struct AnalyticsEventWrappedAction: Action {
+    public init(event: AnalyticsEvent, action: Action) {
+        self.event = event
+        self.action = action
+    }
+
+    public var event: AnalyticsEvent
+    public var action: Action
+}

--- a/Core/Source/MVVM/ViewModel.swift
+++ b/Core/Source/MVVM/ViewModel.swift
@@ -66,11 +66,12 @@ public enum ViewModelUserEvent {
 /// menus.
 public struct SecondaryActionInfo {
 
-    public init(action: Action, title: String, state: State = .off, enabled: Bool = true) {
+    public init(action: Action, title: String, state: State = .off, enabled: Bool = true, event: AnalyticsEvent? = nil) {
         self.action = action
         self.title = title
         self.state = state
         self.enabled = enabled
+        self.event = event
     }
 
     /// State of the secondary action. Note that this differs from enabled, but instead represents whether the action
@@ -85,6 +86,7 @@ public struct SecondaryActionInfo {
     public let title: String
     public let state: State
     public let enabled: Bool
+    public let event: AnalyticsEvent?
 }
 
 /// Represents a secondary action to be displayed in a list to the user (typically from right-click or long-press).

--- a/Pilot.xcodeproj/project.pbxproj
+++ b/Pilot.xcodeproj/project.pbxproj
@@ -121,6 +121,8 @@
 		A455A7E71E5F6C3900F63A37 /* PilotUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A455A7E51E5F6C3900F63A37 /* PilotUI.swift */; };
 		A460CC831E56195F00F9AC6F /* Downcast.swift in Sources */ = {isa = PBXBuildFile; fileRef = A460CC821E56195F00F9AC6F /* Downcast.swift */; };
 		A460CC841E56195F00F9AC6F /* Downcast.swift in Sources */ = {isa = PBXBuildFile; fileRef = A460CC821E56195F00F9AC6F /* Downcast.swift */; };
+		A468F72B1EC2A197009717A4 /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = A468F72A1EC2A197009717A4 /* Analytics.swift */; };
+		A468F7981EC37892009717A4 /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = A468F72A1EC2A197009717A4 /* Analytics.swift */; };
 		A478F9321D3850EB000B2ADB /* NestedModelCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A478F92A1D3850B5000B2ADB /* NestedModelCollectionView.swift */; };
 		A47FC6691D909DFB00529DA9 /* LayoutConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CACF591D6FCBFC003D572D /* LayoutConstraints.swift */; };
 		A4AED3D51D402D73001F3524 /* MappedModelCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4AED3D41D402D73001F3524 /* MappedModelCollection.swift */; };
@@ -261,6 +263,7 @@
 		A437EDB01E56628900F67B37 /* AsyncModelCollectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AsyncModelCollectionTests.swift; path = Core/Tests/MVVM/AsyncModelCollectionTests.swift; sourceTree = "<group>"; };
 		A455A7E51E5F6C3900F63A37 /* PilotUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PilotUI.swift; path = UI/Tests/PilotUI.swift; sourceTree = "<group>"; };
 		A460CC821E56195F00F9AC6F /* Downcast.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Downcast.swift; path = Core/Source/Downcast.swift; sourceTree = "<group>"; };
+		A468F72A1EC2A197009717A4 /* Analytics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Analytics.swift; path = Core/Source/MVVM/Analytics.swift; sourceTree = "<group>"; };
 		A478F92A1D3850B5000B2ADB /* NestedModelCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = NestedModelCollectionView.swift; path = UI/Source/CollectionViews/ios/Nested/NestedModelCollectionView.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		A4AED3D41D402D73001F3524 /* MappedModelCollection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = MappedModelCollection.swift; path = Core/Source/MVVM/MappedModelCollection.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		A4AED3D71D402EBB001F3524 /* MappedModelCollectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MappedModelCollectionTests.swift; path = Core/Tests/MVVM/MappedModelCollectionTests.swift; sourceTree = "<group>"; };
@@ -529,8 +532,8 @@
 			isa = PBXGroup;
 			children = (
 				692936101E130468001303D2 /* Action.swift */,
+				A468F72A1EC2A197009717A4 /* Analytics.swift */,
 				A437EDAD1E5660CE00F67B37 /* AsyncModelCollection.swift */,
-				A437EDAA1E5655AD00F67B37 /* SimpleModelCollection.swift */,
 				69F89E751C52F06200F08E28 /* Context.swift */,
 				022862571DB0070100FCD03F /* DiffEngine.swift */,
 				6919D2BF1C90DC3A0075F997 /* EmptyModelCollection.swift */,
@@ -540,6 +543,7 @@
 				69F89E741C52F06200F08E28 /* ModelCollection.swift */,
 				D5DF48131CAAC2F200F611E6 /* MultiplexModelCollection.swift */,
 				022120341DFB807C007C4039 /* ScoredModelCollection.swift */,
+				A437EDAA1E5655AD00F67B37 /* SimpleModelCollection.swift */,
 				698F3F7E1CE543DB00076B8C /* StaticModel.swift */,
 				021CB8E91D6767D90062D5B3 /* StaticModelCollection.swift */,
 				6988476A1CE6459B0075D205 /* StaticViewBindingProvider.swift */,
@@ -951,6 +955,7 @@
 				69F89E7A1C52F06200F08E28 /* Context.swift in Sources */,
 				D560D4621D136E11000DA826 /* FileLogger.swift in Sources */,
 				69F89E7B1C52F06200F08E28 /* Model.swift in Sources */,
+				A468F7981EC37892009717A4 /* Analytics.swift in Sources */,
 				69AECEF71CAB07FF00EEE780 /* FilteredModelCollection.swift in Sources */,
 				0263D8081D6CCE6C0042415E /* StaticModelCollection.swift in Sources */,
 				02AADF511D6E433E00587167 /* SwitchableModelCollection.swift in Sources */,
@@ -1053,6 +1058,7 @@
 				022137181DA444D20013487F /* ObservableData.swift in Sources */,
 				696534A71D1710D400DF97CB /* StaticModel.swift in Sources */,
 				696534A81D1710D400DF97CB /* StaticViewBindingProvider.swift in Sources */,
+				A468F72B1EC2A197009717A4 /* Analytics.swift in Sources */,
 				696534A21D1710D400DF97CB /* FilteredModelCollection.swift in Sources */,
 				6965349F1D1710CB00DF97CB /* Logger.swift in Sources */,
 				02AADF501D6E433E00587167 /* SwitchableModelCollection.swift in Sources */,

--- a/UI/Source/AppKitExtensions/NSMenu+Action.swift
+++ b/UI/Source/AppKitExtensions/NSMenu+Action.swift
@@ -19,7 +19,7 @@ extension NSMenu {
                 let menuItem = NSMenuItem(title: info.title, action: action, keyEquivalent: "")
                 menuItem.isEnabled = info.enabled
                 menuItem.state = info.state.toNSState()
-                menuItem.representedObject = MenuItemActionWrapper(info.action)
+                menuItem.representedObject = MenuItemActionWrapper(info.action, event: info.event)
                 menu.addItem(menuItem)
 
             case .info(let string):
@@ -46,6 +46,14 @@ extension NSMenuItem {
         }
         return nil
     }
+
+    /// TODO:(danielh) docs
+    public var representedEvent: AnalyticsEvent? {
+        if let wrapper = representedObject as? MenuItemActionWrapper {
+            return wrapper.wrappedEvent
+        }
+        return nil
+    }
 }
 
 extension SecondaryActionInfo.State {
@@ -64,10 +72,12 @@ extension SecondaryActionInfo.State {
 /// Helper class to wrap value-type `Action`s.
 fileprivate final class MenuItemActionWrapper: NSObject {
 
-    fileprivate convenience init(_ action: Action) {
+    fileprivate convenience init(_ action: Action, event: AnalyticsEvent?) {
         self.init()
         wrappedAction = action
+        wrappedEvent = event
     }
     fileprivate var wrappedAction: Action?
+    fileprivate var wrappedEvent: AnalyticsEvent?
 }
 

--- a/UI/Source/CollectionViews/mac/CollectionViewController.swift
+++ b/UI/Source/CollectionViews/mac/CollectionViewController.swift
@@ -369,6 +369,9 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
             return
         }
         action.send(from: context)
+        if let event = menuItem.representedEvent else {
+            SendAnalyticsEventAction(event: event).send(from: context)
+        }
     }
 
     private func registerForMenuTrackingEnd(_ menu: NSMenu, item: CollectionViewHostItem) {


### PR DESCRIPTION
Not ready to merge, needs docs and testing, but wanted to get feedback before going any further on this path.

Basically `AnalyticsEventWrappedAction` could be dropped in anywhere you expect an `Action` and it would fire your analytics event in a separate action when it is sent. This has a few advantages:

1. Allows existing APIs to remain unencumbered by analytics code (for example the SecondaryActionInfo), while allowing analytics events to be pretty easily inserted at various parts of the stack
2. Moves all the actual analytics sending code to one choke point in your root context, which makes it harder to lose events that are sometimes just tacked onto Actions ad-hoc
3. Allows you to capture `SendAnalyticsEventAction` tack on additional metadata as it goes up the context chain

The big downside is [this dynamic typecheck and dispatch](https://github.com/dropbox/pilot/pull/46/files#diff-29200dd54095756bfd909d5229a9c875R28) to get around the fact that the default implementation will (almost) always win out since you're action on a type of Action rather than a concrete type. Would love alternatives if you have any ideas!

The other option I considered is adding an optional protocol that the `Action` could conform to something like:

```swift
protocol AnalyticsEventInstrumentedAction {
    var event: AnalyticsEvent? { get }
}
```

And then you could do the same check in `send(from:)` for conditional conformance to that protocol and grab the event right out of that. I like this less because it makes the event always a accessible property on the action itself and i think it will be less clear that you don't have any responsibility to send that event, and that changes to that event after its fired are going to be meaningless etc...