### PR TITLE
Only use rebind when view models are the same type

### DIFF
--- a/UI/Source/CollectionViews/CollectionViewModelDataSource.swift
+++ b/UI/Source/CollectionViews/CollectionViewModelDataSource.swift
@@ -653,8 +653,12 @@ extension CollectionViewModelDataSource: UICollectionViewDataSource {
                 }
 
                 // If the size hasn't changed, simply rebind the view rather than perform a full cell reload.
-                if let old = oldCachedViewModel,
-                    let new = newCachedViewModel , old.preferredLayout == new.preferredLayout {
+                if
+                    let old = oldCachedViewModel,
+                    let new = newCachedViewModel,
+                    type(of: old.viewModel) == type(of: new.viewModel) &&
+                    old.preferredLayout == new.preferredLayout
+                {
                     rebindViewAtIndexPath(indexPath.indexPath, toViewModel: new.viewModel)
                 } else {
                     indexPathsToReload.append(indexPath.indexPath)
@@ -980,8 +984,12 @@ extension CollectionViewModelDataSource: NSCollectionViewDataSource {
                 }
 
                 // If the size hasn't changed, simply rebind the view rather than perform a full cell reload.
-                if let old = oldCachedViewModel,
-                    let new = newCachedViewModel , old.preferredLayout == new.preferredLayout {
+                if
+                    let old = oldCachedViewModel,
+                    let new = newCachedViewModel,
+                    type(of: old.viewModel) == type(of: new.viewModel) &&
+                    old.preferredLayout == new.preferredLayout
+                {
                     rebindViewAtIndexPath(indexPath.indexPath, toViewModel: new.viewModel)
                 } else {
                     reloadSet.insert(indexPath.indexPath)


### PR DESCRIPTION
This fixes an issue where a view model binding provider that vends different view model types based on model state could cause an exception when an update that changed that model state causes the data source to try and rebind a different view model than the view is expecting.