### PR TITLE
Extend view models ability to respond to keyboard ViewModelUserEvents

### DIFF
--- a/Core/Source/MVVM/ViewModel.swift
+++ b/Core/Source/MVVM/ViewModel.swift
@@ -38,30 +38,6 @@ public protocol ViewModel {
     func secondaryActions(for event: ViewModelUserEvent) -> [SecondaryAction]
 }
 
-/// Event types that view models may handle, typically sent from the view layer.
-public enum ViewModelUserEvent {
-    /// On mouse-supporting platforms, represents a click by the user.
-    case click
-
-    /// Represents the user typing enter/return.
-    case enterKey
-
-    /// Represents the user typing space.
-    case spaceKey
-
-    /// Reprsents the user performing a long-press on the target view model.
-    case longPress
-
-    /// On mouse-supporting platforms, represents a secondary (right) click by the user.
-    case secondaryClick
-
-    /// On any platform, represents the target being selected (via mouse, programatically, or tap).
-    case select
-
-    /// On touch platforms, represents the target receiving a single tap.
-    case tap
-}
-
 /// Wraps an `Action` with additional data to be rendered in a "secondary" context like context menus or long-press
 /// menus.
 public struct SecondaryActionInfo {
@@ -102,7 +78,11 @@ public extension ViewModel {
 
     func handleUserEvent(_ event: ViewModelUserEvent) {}
 
+    /// By default returns true for all non-keyboard events.
     func canHandleUserEvent(_ event: ViewModelUserEvent) -> Bool {
+        if case .keyDown = event {
+            return false
+        }
         return true
     }
 

--- a/Core/Source/MVVM/ViewModelUserEvents.swift
+++ b/Core/Source/MVVM/ViewModelUserEvents.swift
@@ -1,0 +1,206 @@
+import Foundation
+
+/// Event types that view models may handle, typically sent from the view layer.
+public enum ViewModelUserEvent {
+    /// On mouse-supporting platforms, represents a click by the user.
+    case click
+
+    /// Represents the user typing a key with modifier flags.
+    case keyDown(EventKeyCode, EventKeyModifierFlags)
+
+    /// Reprsents the user performing a long-press on the target view model.
+    case longPress
+
+    /// On mouse-supporting platforms, represents a secondary (right) click by the user.
+    case secondaryClick
+
+    /// On any platform, represents the target being selected (via mouse, programatically, or tap).
+    case select
+
+    /// On touch platforms, represents the target receiving a single tap.
+    case tap
+}
+
+// swiftlint:disable type_name
+
+/// Possible key code values for `NSEvent.keyCode` - taken from <HIToolbox/Events.h>.
+@objc
+public enum EventKeyCode: UInt16, RawRepresentable {
+    case `return`                  = 0x24
+    case tab                       = 0x30
+    case space                     = 0x31
+    case delete                    = 0x33
+    case escape                    = 0x35
+    case command                   = 0x37
+    case shift                     = 0x38
+    case capsLock                  = 0x39
+    case option                    = 0x3A
+    case control                   = 0x3B
+    case rightShift                = 0x3C
+    case rightOption               = 0x3D
+    case rightControl              = 0x3E
+    case function                  = 0x3F
+    case f17                       = 0x40
+    case volumeUp                  = 0x48
+    case volumeDown                = 0x49
+    case mute                      = 0x4A
+    case f18                       = 0x4F
+    case f19                       = 0x50
+    case f20                       = 0x5A
+    case f5                        = 0x60
+    case f6                        = 0x61
+    case f7                        = 0x62
+    case f3                        = 0x63
+    case f8                        = 0x64
+    case f9                        = 0x65
+    case f11                       = 0x67
+    case f13                       = 0x69
+    case f16                       = 0x6A
+    case f14                       = 0x6B
+    case f10                       = 0x6D
+    case f12                       = 0x6F
+    case f15                       = 0x71
+    case help                      = 0x72
+    case home                      = 0x73
+    case pageUp                    = 0x74
+    case forwardDelete             = 0x75
+    case f4                        = 0x76
+    case end                       = 0x77
+    case f2                        = 0x78
+    case pageDown                  = 0x79
+    case f1                        = 0x7A
+    case leftArrow                 = 0x7B
+    case rightArrow                = 0x7C
+    case downArrow                 = 0x7D
+    case upArrow                   = 0x7E
+    case A                         = 0x00
+    case S                         = 0x01
+    case D                         = 0x02
+    case F                         = 0x03
+    case H                         = 0x04
+    case G                         = 0x05
+    case Z                         = 0x06
+    case X                         = 0x07
+    case C                         = 0x08
+    case V                         = 0x09
+    case B                         = 0x0B
+    case Q                         = 0x0C
+    case W                         = 0x0D
+    case E                         = 0x0E
+    case R                         = 0x0F
+    case Y                         = 0x10
+    case T                         = 0x11
+    case one                       = 0x12
+    case two                       = 0x13
+    case three                     = 0x14
+    case four                      = 0x15
+    case six                       = 0x16
+    case five                      = 0x17
+    case Equal                     = 0x18
+    case nine                      = 0x19
+    case seven                     = 0x1A
+    case Minus                     = 0x1B
+    case eight                     = 0x1C
+    case zero                      = 0x1D
+    case RightBracket              = 0x1E
+    case O                         = 0x1F
+    case U                         = 0x20
+    case LeftBracket               = 0x21
+    case I                         = 0x22
+    case P                         = 0x23
+    case L                         = 0x25
+    case J                         = 0x26
+    case Quote                     = 0x27
+    case K                         = 0x28
+    case Semicolon                 = 0x29
+    case Backslash                 = 0x2A
+    case Comma                     = 0x2B
+    case Slash                     = 0x2C
+    case N                         = 0x2D
+    case M                         = 0x2E
+    case Period                    = 0x2F
+    case Grave                     = 0x32
+    case KeypadDecimal             = 0x41
+    case KeypadMultiply            = 0x43
+    case KeypadPlus                = 0x45
+    case KeypadClear               = 0x47
+    case KeypadDivide              = 0x4B
+    case KeypadMinus               = 0x4E
+    case KeypadEquals              = 0x51
+    case Keypad0                   = 0x52
+    case Keypad1                   = 0x53
+    case Keypad2                   = 0x54
+    case Keypad3                   = 0x55
+    case Keypad4                   = 0x56
+    case Keypad5                   = 0x57
+    case Keypad6                   = 0x58
+    case Keypad7                   = 0x59
+    case Keypad8                   = 0x5B
+    case Keypad9                   = 0x5C
+
+
+    // Pilot Additions
+    case enter                     = 0x4C
+    case unknown                   = 0xFF
+}
+
+/// Simple wrapper around NSEvent.ModifierFlags to avoid importing AppKit.
+public struct EventKeyModifierFlags: OptionSet {
+
+    // MARK: OptionSet
+
+    public init(rawValue: UInt) {
+        self.rawValue = rawValue
+    }
+
+    public let rawValue: UInt
+
+    // MARK: Values
+
+    /// Set if Caps Lock key is pressed.
+    public static var capsLock = EventKeyModifierFlags(rawValue: 1<<0)
+    /// Set if Shift key is pressed.
+    public static var shift = EventKeyModifierFlags(rawValue: 1<<1)
+    /// Set if Control key is pressed.
+    public static var control = EventKeyModifierFlags(rawValue: 1<<2)
+    /// Set if Option or Alternate key is pressed.
+    public static var option = EventKeyModifierFlags(rawValue: 1<<3)
+    /// Set if Command key is pressed.
+    public static var command = EventKeyModifierFlags(rawValue: 1<<4)
+    /// Set if Function key is pressed.
+    public static var function = EventKeyModifierFlags(rawValue: 1<<5)
+}
+
+extension ViewModelUserEvent: Hashable {
+    public var hashValue: Int {
+        switch self {
+        case .click:
+            return 1<<0
+        case .keyDown(let key, let flags):
+            return 1<<2 ^ key.rawValue.hashValue ^ flags.rawValue.hashValue
+        case .longPress:
+            return 1<<2
+        case .secondaryClick:
+            return 1<<3
+        case .select:
+            return 1<<4
+        case .tap:
+            return 1<<5
+        }
+    }
+
+    public static func ==(lhs: ViewModelUserEvent, rhs: ViewModelUserEvent) -> Bool {
+        switch (lhs, rhs) {
+        case (.click, .click), (.longPress, .longPress), (.secondaryClick, .secondaryClick), (.select, .select),
+             (.tap, .tap):
+            return true
+        case (.keyDown(let lKey, let lModifiers), .keyDown(let rKey, let rModifiers)):
+            return lKey == rKey && lModifiers == rModifiers
+        case (.click, _), (.longPress, _), (.secondaryClick, _), (.select, _), (.tap, _), (.keyDown, _):
+            return false
+        }
+    }
+
+    public static var spaceKey = ViewModelUserEvent.keyDown(.space, [])
+    public static var enterKey = ViewModelUserEvent.keyDown(.enter, [])
+}

--- a/Core/Source/MVVM/ViewModelUserEvents.swift
+++ b/Core/Source/MVVM/ViewModelUserEvents.swift
@@ -21,6 +21,67 @@ public enum ViewModelUserEvent {
     case tap
 }
 
+/// Simple wrapper around NSEvent.ModifierFlags to avoid importing AppKit.
+public struct EventKeyModifierFlags: OptionSet {
+
+    // MARK: OptionSet
+
+    public init(rawValue: UInt) {
+        self.rawValue = rawValue
+    }
+
+    public let rawValue: UInt
+
+    // MARK: Values
+
+    /// Set if Caps Lock key is pressed.
+    public static var capsLock = EventKeyModifierFlags(rawValue: 1<<0)
+    /// Set if Shift key is pressed.
+    public static var shift = EventKeyModifierFlags(rawValue: 1<<1)
+    /// Set if Control key is pressed.
+    public static var control = EventKeyModifierFlags(rawValue: 1<<2)
+    /// Set if Option or Alternate key is pressed.
+    public static var option = EventKeyModifierFlags(rawValue: 1<<3)
+    /// Set if Command key is pressed.
+    public static var command = EventKeyModifierFlags(rawValue: 1<<4)
+    /// Set if Function key is pressed.
+    public static var function = EventKeyModifierFlags(rawValue: 1<<5)
+}
+
+extension ViewModelUserEvent: Hashable {
+    public var hashValue: Int {
+        switch self {
+        case .click:
+            return 1<<0
+        case .keyDown(let key, let flags):
+            return "keyDown-\(key)-\(flags)".hashValue
+        case .longPress:
+            return 1<<1
+        case .secondaryClick:
+            return 1<<2
+        case .select:
+            return 1<<3
+        case .tap:
+            return 1<<4
+        }
+    }
+
+    public static func ==(lhs: ViewModelUserEvent, rhs: ViewModelUserEvent) -> Bool {
+        switch (lhs, rhs) {
+        case (.click, .click), (.longPress, .longPress), (.secondaryClick, .secondaryClick), (.select, .select),
+             (.tap, .tap):
+            return true
+        case (.keyDown(let lKey, let lModifiers), .keyDown(let rKey, let rModifiers)):
+            return lKey == rKey && lModifiers == rModifiers
+        case (.click, _), (.longPress, _), (.secondaryClick, _), (.select, _), (.tap, _), (.keyDown, _):
+            return false
+        }
+    }
+
+    public static var spaceKey = ViewModelUserEvent.keyDown(.space, [])
+    public static var enterKey = ViewModelUserEvent.keyDown(.enter, [])
+}
+
 // swiftlint:disable type_name
 
 /// Possible key code values for `NSEvent.keyCode` - taken from <HIToolbox/Events.h>.
@@ -142,65 +203,4 @@ public enum EventKeyCode: UInt16, RawRepresentable {
     // Pilot Additions
     case enter                     = 0x4C
     case unknown                   = 0xFF
-}
-
-/// Simple wrapper around NSEvent.ModifierFlags to avoid importing AppKit.
-public struct EventKeyModifierFlags: OptionSet {
-
-    // MARK: OptionSet
-
-    public init(rawValue: UInt) {
-        self.rawValue = rawValue
-    }
-
-    public let rawValue: UInt
-
-    // MARK: Values
-
-    /// Set if Caps Lock key is pressed.
-    public static var capsLock = EventKeyModifierFlags(rawValue: 1<<0)
-    /// Set if Shift key is pressed.
-    public static var shift = EventKeyModifierFlags(rawValue: 1<<1)
-    /// Set if Control key is pressed.
-    public static var control = EventKeyModifierFlags(rawValue: 1<<2)
-    /// Set if Option or Alternate key is pressed.
-    public static var option = EventKeyModifierFlags(rawValue: 1<<3)
-    /// Set if Command key is pressed.
-    public static var command = EventKeyModifierFlags(rawValue: 1<<4)
-    /// Set if Function key is pressed.
-    public static var function = EventKeyModifierFlags(rawValue: 1<<5)
-}
-
-extension ViewModelUserEvent: Hashable {
-    public var hashValue: Int {
-        switch self {
-        case .click:
-            return 1<<0
-        case .keyDown(let key, let flags):
-            return 1<<2 ^ key.rawValue.hashValue ^ flags.rawValue.hashValue
-        case .longPress:
-            return 1<<2
-        case .secondaryClick:
-            return 1<<3
-        case .select:
-            return 1<<4
-        case .tap:
-            return 1<<5
-        }
-    }
-
-    public static func ==(lhs: ViewModelUserEvent, rhs: ViewModelUserEvent) -> Bool {
-        switch (lhs, rhs) {
-        case (.click, .click), (.longPress, .longPress), (.secondaryClick, .secondaryClick), (.select, .select),
-             (.tap, .tap):
-            return true
-        case (.keyDown(let lKey, let lModifiers), .keyDown(let rKey, let rModifiers)):
-            return lKey == rKey && lModifiers == rModifiers
-        case (.click, _), (.longPress, _), (.secondaryClick, _), (.select, _), (.tap, _), (.keyDown, _):
-            return false
-        }
-    }
-
-    public static var spaceKey = ViewModelUserEvent.keyDown(.space, [])
-    public static var enterKey = ViewModelUserEvent.keyDown(.enter, [])
 }

--- a/Pilot.xcodeproj/project.pbxproj
+++ b/Pilot.xcodeproj/project.pbxproj
@@ -133,6 +133,8 @@
 		A468F8031EC3B7EF009717A4 /* CompoundAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A468F7FD1EC3B61D009717A4 /* CompoundAction.swift */; };
 		A478F9321D3850EB000B2ADB /* NestedModelCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A478F92A1D3850B5000B2ADB /* NestedModelCollectionView.swift */; };
 		A47FC6691D909DFB00529DA9 /* LayoutConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CACF591D6FCBFC003D572D /* LayoutConstraints.swift */; };
+		A4897B631F95582100727514 /* ViewModelUserEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4897B621F95582100727514 /* ViewModelUserEvents.swift */; };
+		A4897B641F95582100727514 /* ViewModelUserEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4897B621F95582100727514 /* ViewModelUserEvents.swift */; };
 		A4AED3D51D402D73001F3524 /* MappedModelCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4AED3D41D402D73001F3524 /* MappedModelCollection.swift */; };
 		A4AED3D61D402D73001F3524 /* MappedModelCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4AED3D41D402D73001F3524 /* MappedModelCollection.swift */; };
 		A4AED3DA1D402F26001F3524 /* MappedModelCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4AED3D71D402EBB001F3524 /* MappedModelCollectionTests.swift */; };
@@ -278,6 +280,7 @@
 		A468F7FD1EC3B61D009717A4 /* CompoundAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CompoundAction.swift; path = Core/Source/MVVM/CompoundAction.swift; sourceTree = "<group>"; };
 		A468F7FF1EC3B7AE009717A4 /* CompoundActionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CompoundActionTests.swift; path = Core/Tests/MVVM/CompoundActionTests.swift; sourceTree = "<group>"; };
 		A478F92A1D3850B5000B2ADB /* NestedModelCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = NestedModelCollectionView.swift; path = UI/Source/CollectionViews/ios/Nested/NestedModelCollectionView.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		A4897B621F95582100727514 /* ViewModelUserEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ViewModelUserEvents.swift; path = Core/Source/MVVM/ViewModelUserEvents.swift; sourceTree = "<group>"; };
 		A4AED3D41D402D73001F3524 /* MappedModelCollection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = MappedModelCollection.swift; path = Core/Source/MVVM/MappedModelCollection.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		A4AED3D71D402EBB001F3524 /* MappedModelCollectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MappedModelCollectionTests.swift; path = Core/Tests/MVVM/MappedModelCollectionTests.swift; sourceTree = "<group>"; };
 		A4C8D5991CF23F3900F9721A /* FilteredModelCollectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = FilteredModelCollectionTests.swift; path = Core/Tests/MVVM/FilteredModelCollectionTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -583,6 +586,7 @@
 				69F89E781C52F06200F08E28 /* View.swift */,
 				693A60C91CAC80F800E0D2A3 /* ViewLayout.swift */,
 				69F89E771C52F06200F08E28 /* ViewModel.swift */,
+				A4897B621F95582100727514 /* ViewModelUserEvents.swift */,
 			);
 			name = MVVM;
 			sourceTree = "<group>";
@@ -1001,6 +1005,7 @@
 				A437EDAC1E5655AD00F67B37 /* SimpleModelCollection.swift in Sources */,
 				A437EDB61E567AE900F67B37 /* Async.swift in Sources */,
 				A460CC841E56195F00F9AC6F /* Downcast.swift in Sources */,
+				A4897B641F95582100727514 /* ViewModelUserEvents.swift in Sources */,
 				698F3F7F1CE543DB00076B8C /* StaticModel.swift in Sources */,
 				69F89E791C52F06200F08E28 /* ModelCollection.swift in Sources */,
 				D560D4611D136E11000DA826 /* ConsoleLogger.swift in Sources */,
@@ -1111,6 +1116,7 @@
 				A460CC831E56195F00F9AC6F /* Downcast.swift in Sources */,
 				A437EDB51E567AE800F67B37 /* Async.swift in Sources */,
 				696534AB1D1710D400DF97CB /* View.swift in Sources */,
+				A4897B631F95582100727514 /* ViewModelUserEvents.swift in Sources */,
 				022862581DB0070100FCD03F /* DiffEngine.swift in Sources */,
 				692936111E130468001303D2 /* Action.swift in Sources */,
 				696534A41D1710D400DF97CB /* Context.swift in Sources */,

--- a/UI/Source/AppKitExtensions/NSEvent+Keys.swift
+++ b/UI/Source/AppKitExtensions/NSEvent+Keys.swift
@@ -1,6 +1,12 @@
 import Foundation
 import Pilot
 
+#if swift(>=3.2)
+public typealias AppKitEventModifierFlags = NSEvent.ModifierFlags
+#else
+public typealias AppKitEventModifierFlags = NSEventModifierFlags
+#endif
+
 public extension NSEvent {
 
     /// Returns a semantic `EventKeyCode` value (or .Unknown) for the target event.
@@ -13,7 +19,7 @@ public extension NSEvent {
     }
 }
 
-extension NSEvent.ModifierFlags {
+extension AppKitEventModifierFlags {
     public var eventKeyModifierFlags: EventKeyModifierFlags {
         var result = EventKeyModifierFlags(rawValue: 0)
         if contains(.capsLock) {
@@ -39,8 +45,8 @@ extension NSEvent.ModifierFlags {
 }
 
 extension EventKeyModifierFlags {
-    public var modifierFlags: NSEvent.ModifierFlags {
-        var result = NSEvent.ModifierFlags(rawValue: 0)
+    public var modifierFlags: AppKitEventModifierFlags {
+        var result = AppKitEventModifierFlags(rawValue: 0)
         if contains(.capsLock) {
             result.formUnion(.capsLock)
         }

--- a/UI/Source/AppKitExtensions/NSEvent+Keys.swift
+++ b/UI/Source/AppKitExtensions/NSEvent+Keys.swift
@@ -1,67 +1,64 @@
 import Foundation
-
-// swiftlint:disable type_name
-
-/// Possible key code values for `NSEvent.keyCode` - taken from <HIToolbox/Events.h>.
-@objc
-public enum EventKeyCode: UInt16, RawRepresentable {
-    case `return`                    = 0x24
-    case tab                       = 0x30
-    case space                     = 0x31
-    case delete                    = 0x33
-    case escape                    = 0x35
-    case command                   = 0x37
-    case shift                     = 0x38
-    case capsLock                  = 0x39
-    case option                    = 0x3A
-    case control                   = 0x3B
-    case rightShift                = 0x3C
-    case rightOption               = 0x3D
-    case rightControl              = 0x3E
-    case function                  = 0x3F
-    case f17                       = 0x40
-    case volumeUp                  = 0x48
-    case volumeDown                = 0x49
-    case mute                      = 0x4A
-    case f18                       = 0x4F
-    case f19                       = 0x50
-    case f20                       = 0x5A
-    case f5                        = 0x60
-    case f6                        = 0x61
-    case f7                        = 0x62
-    case f3                        = 0x63
-    case f8                        = 0x64
-    case f9                        = 0x65
-    case f11                       = 0x67
-    case f13                       = 0x69
-    case f16                       = 0x6A
-    case f14                       = 0x6B
-    case f10                       = 0x6D
-    case f12                       = 0x6F
-    case f15                       = 0x71
-    case help                      = 0x72
-    case home                      = 0x73
-    case pageUp                    = 0x74
-    case forwardDelete             = 0x75
-    case f4                        = 0x76
-    case end                       = 0x77
-    case f2                        = 0x78
-    case pageDown                  = 0x79
-    case f1                        = 0x7A
-    case leftArrow                 = 0x7B
-    case rightArrow                = 0x7C
-    case downArrow                 = 0x7D
-    case upArrow                   = 0x7E
-
-    // Pilot Additions
-    case enter                     = 0x4C
-    case unknown                   = 0x0
-}
+import Pilot
 
 public extension NSEvent {
 
     /// Returns a semantic `EventKeyCode` value (or .Unknown) for the target event.
     public var eventKeyCode: EventKeyCode {
         return EventKeyCode(rawValue: keyCode) ?? .unknown
+    }
+
+    public var eventKeyModifierFlags: EventKeyModifierFlags {
+        return modifierFlags.eventKeyModifierFlags
+    }
+}
+
+extension NSEvent.ModifierFlags {
+    public var eventKeyModifierFlags: EventKeyModifierFlags {
+        var result = EventKeyModifierFlags(rawValue: 0)
+        if contains(.capsLock) {
+            result.formUnion(.capsLock)
+        }
+        if contains(.command) {
+            result.formUnion(.command)
+        }
+        if contains(.control) {
+            result.formUnion(.control)
+        }
+        if contains(.function) {
+            result.formUnion(.function)
+        }
+        if contains(.option) {
+            result.formUnion(.option)
+        }
+        if contains(.shift) {
+            result.formUnion(.shift)
+        }
+        return result
+    }
+}
+
+extension EventKeyModifierFlags {
+    public var modifierFlags: NSEvent.ModifierFlags {
+        var result = NSEvent.ModifierFlags(rawValue: 0)
+        if contains(.capsLock) {
+            result.formUnion(.capsLock)
+        }
+        if contains(.command) {
+            result.formUnion(.command)
+        }
+        if contains(.control) {
+            result.formUnion(.control)
+        }
+        if contains(.function) {
+            result.formUnion(.function)
+        }
+        if contains(.option) {
+            result.formUnion(.option)
+        }
+        if contains(.shift) {
+            result.formUnion(.shift)
+        }
+        return result
     }
 }

--- a/UI/Source/CollectionViews/mac/CollectionView.swift
+++ b/UI/Source/CollectionViews/mac/CollectionView.swift
@@ -1,16 +1,17 @@
 import Foundation
+import Pilot
 
 /// Protocol extending `NSCollectionViewDelegate` with a few missing callbacks around item clicking and key events.
 @objc
 public protocol CollectionViewDelegate: NSCollectionViewDelegate {
 
-    /// Invoked when the return or enter key is invoked - clients may check the selection state to determine if an
-    /// action should be taken. If true is returned from this function event is consumed.
-    @objc optional func collectionViewDidReceiveReturnKey(_ collectionView: NSCollectionView) -> Bool
-
-    /// Invoked when the return or space key is invoked - clients may check the selection state to determine if an
-    /// action should be taken. If true is returned from this function event is consumed.
-    @objc optional func collectionViewDidReceiveSpaceKey(_ collectionView: NSCollectionView) -> Bool
+    /// Invoked when a keyboard key is pressed - clients may check the selection state to determine if an action should
+    /// be taken. If true is returned from this function event is consumed.
+    @objc optional func collectionViewDidReceiveKeyEvent(
+        _ collectionView: NSCollectionView,
+        key: EventKeyCode,
+        modifiers: NSEvent.ModifierFlags
+    ) -> Bool
 
     /// Invoked when a specific index path is clicked upon - this allows the client to handle clicks without breaking
     /// the typical `NSCollectionView` selection state (otherwise, underlying item views do not get all mouse events).
@@ -48,13 +49,12 @@ public final class CollectionView: NSCollectionView {
     // MARK: NSResponder
 
     public override func keyDown(with event: NSEvent) {
+        let handled = internalDelegate?.collectionViewDidReceiveKeyEvent?(
+            self,
+            key: event.eventKeyCode,
+            modifiers: event.eventKeyModifierFlags.modifierFlags)
+        guard handled != true else { return }
         switch event.eventKeyCode {
-        case .return, .enter:
-            guard internalDelegate?.collectionViewDidReceiveReturnKey?(self) != true else { return }
-            super.keyDown(with: event)
-        case .space:
-            guard internalDelegate?.collectionViewDidReceiveSpaceKey?(self) != true else { return }
-            super.keyDown(with: event)
         case .upArrow, .downArrow:
             let oldSelectionIndexPaths = selectionIndexPaths
 

--- a/UI/Source/CollectionViews/mac/CollectionView.swift
+++ b/UI/Source/CollectionViews/mac/CollectionView.swift
@@ -10,7 +10,7 @@ public protocol CollectionViewDelegate: NSCollectionViewDelegate {
     @objc optional func collectionViewDidReceiveKeyEvent(
         _ collectionView: NSCollectionView,
         key: EventKeyCode,
-        modifiers: NSEvent.ModifierFlags
+        modifiers: AppKitEventModifierFlags
     ) -> Bool
 
     /// Invoked when a specific index path is clicked upon - this allows the client to handle clicks without breaking

--- a/UI/Source/CollectionViews/mac/CollectionViewController.swift
+++ b/UI/Source/CollectionViews/mac/CollectionViewController.swift
@@ -218,23 +218,16 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
 
     // MARK: CollectionViewDelegate
 
-    open func collectionViewDidReceiveReturnKey(_ collectionView: NSCollectionView) -> Bool {
-        // Right now, only a single selected item is supported for the return/enter keys.
+    open func collectionViewDidReceiveKeyEvent(
+        _ collectionView: NSCollectionView,
+        key: EventKeyCode,
+        modifiers: NSEvent.ModifierFlags
+    ) -> Bool {
         guard let indexPath = collectionView.selectionIndexPaths.first else { return false }
         guard let vm = viewModelAtIndexPath(indexPath) else { return false }
-        if vm.canHandleUserEvent(.enterKey) {
-            vm.handleUserEvent(.enterKey)
-            return true
-        }
-        return false
-    }
-
-    open func collectionViewDidReceiveSpaceKey(_ collectionView: NSCollectionView) -> Bool {
-        // Right now, only a single selected item is supported for the space keys.
-        guard let indexPath = collectionView.selectionIndexPaths.first else { return false }
-        guard let vm = viewModelAtIndexPath(indexPath) else { return false }
-        if vm.canHandleUserEvent(.spaceKey) {
-            vm.handleUserEvent(.spaceKey)
+        let event = ViewModelUserEvent.keyDown(key, modifiers.eventKeyModifierFlags)
+        if vm.canHandleUserEvent(event) {
+            vm.handleUserEvent(event)
             return true
         }
         return false

--- a/UI/Source/CollectionViews/mac/CollectionViewController.swift
+++ b/UI/Source/CollectionViews/mac/CollectionViewController.swift
@@ -221,7 +221,7 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
     open func collectionViewDidReceiveKeyEvent(
         _ collectionView: NSCollectionView,
         key: EventKeyCode,
-        modifiers: NSEvent.ModifierFlags
+        modifiers: AppKitEventModifierFlags
     ) -> Bool {
         guard let indexPath = collectionView.selectionIndexPaths.first else { return false }
         guard let vm = viewModelAtIndexPath(indexPath) else { return false }


### PR DESCRIPTION
Instead of specific handling for space and enter keys, view models can now get calls for any keyboard keyDown event, including the modifirers (ex: shift/command/...) and handle them apropriately or ignore and let them continue up the responder chain.