### PR TITLE
RFC: Refactor ViewModel to have a more testable codepath for handling events

### DIFF
--- a/Core/Source/MVVM/SecondaryActionInfo.swift
+++ b/Core/Source/MVVM/SecondaryActionInfo.swift
@@ -35,7 +35,7 @@ public struct SecondaryActionInfo {
             enabled: Bool = true,
             imageName: String? = nil,
             keyEquivalent: String = ""
-            ) {
+        ) {
             self.title = title
             self.state = state
             self.enabled = enabled
@@ -48,7 +48,7 @@ public struct SecondaryActionInfo {
             title: String,
             enabled: Bool = true,
             imageName: String? = nil
-            ) -> Metadata {
+        ) -> Metadata {
             return Metadata(title: title, state: .off, enabled: enabled, imageName: imageName)
         }
     }

--- a/Core/Source/MVVM/SecondaryActionInfo.swift
+++ b/Core/Source/MVVM/SecondaryActionInfo.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Wraps an `Action` with additional data to be rendered in a "secondary" context like context menus or long-press
+/// menus.
+public struct SecondaryActionInfo {
+    public struct Metadata {
+        public let title: String
+        public let state: State
+        public let enabled: Bool
+        public let imageName: String?
+        public let keyEquivalent: String
+
+        /// State of the secondary action. Note that this differs from enabled, but instead represents whether the
+        /// action is "checked" in a list.
+        public enum State: ExpressibleByBooleanLiteral {
+            case on
+            case off
+            case mixed
+
+            public init(booleanLiteral value: BooleanLiteralType) {
+                if value {
+                    self = .on
+                } else {
+                    self = .off
+                }
+            }
+        }
+
+        // Always provide a default value, so that it is easy to create partial Metadata to overlay on top on an
+        // existing item. For example, an AppActionResponder may want to pass up Metadata(state: .on) to add
+        // a checkmark to an item, without knowing the exact name of the action.
+        public init(
+            title: String = "",
+            state: Metadata.State = .off,
+            enabled: Bool = true,
+            imageName: String? = nil,
+            keyEquivalent: String = ""
+            ) {
+            self.title = title
+            self.state = state
+            self.enabled = enabled
+            self.imageName = imageName
+            self.keyEquivalent = keyEquivalent
+        }
+
+        // Enforce some common conventions (for example, state is off, no keyEquivalent).
+        public static func forNestedActions(
+            title: String,
+            enabled: Bool = true,
+            imageName: String? = nil
+            ) -> Metadata {
+            return Metadata(title: title, state: .off, enabled: enabled, imageName: imageName)
+        }
+    }
+
+    public init(metadata: Metadata, action: Action) {
+        self.metadata = metadata
+        self.action = action
+    }
+
+    public let metadata: Metadata
+    public let action: Action
+}
+
+/// Describes a group of nested SecondaryActions.
+public struct NestedActionsInfo {
+    public init(metadata: SecondaryActionInfo.Metadata, actions: [SecondaryAction]) {
+        self.metadata = metadata
+        self.actions = actions
+    }
+
+    public let metadata: SecondaryActionInfo.Metadata
+    public let actions: [SecondaryAction]
+}
+
+/// Represents a secondary action to be displayed in a list to the user (typically from right-click or long-press).
+public enum SecondaryAction {
+    case action(SecondaryActionInfo)
+    case info(String)
+    case separator
+    case nested(NestedActionsInfo)
+}

--- a/Core/Source/MVVM/ViewModel.swift
+++ b/Core/Source/MVVM/ViewModel.swift
@@ -4,6 +4,35 @@ import Foundation
 
 // MARK: ViewModel
 
+/// Protocol representing the view model type, acting acting as the business logic layer providing the necessary data
+/// and methods for `View` binding and responding to user actions.
+///
+/// This interface is shared by both ViewModel and SelectionViewModel and most application code should refer to one of
+/// those more specific protocols.
+public protocol ViewModelType {
+
+    /// Access to the underlying `Context`.
+    var context: Context { get }
+
+    /// Returns the `Action` that should be fired for a given `ViewModelUserEvent`. The default implementation returns
+    /// nil.
+    func actionForUserEvent(_ event: ViewModelUserEvent) -> Action?
+
+    /// An array of secondary actions - typically displayed as a context menu or long-press menu depending on platform.
+    /// Default implementation returns an empty list.
+    func secondaryActions(for event: ViewModelUserEvent) -> [SecondaryAction]
+
+    /// Returns `true` if the target view model type can handle the given user event, `false` if it cannot.
+    ///
+    /// The default implementation calls secondaryActions(for:) for .secondaryClick events and returns `true` if the
+    /// result is not-empty, for all other event types it calls actionForUserEvent(_:) and returns `true` if the
+    /// function returns any non-nil action.
+    func canHandleUserEvent(_ event: ViewModelUserEvent) -> Bool
+
+    /// Invoked on the view model when the view layer wants it to handle a given user event. The default implementation
+    /// sends the action from action(_:) to the context. For most usecases implementing this is unnecessary.
+    func handleUserEvent(_ event: ViewModelUserEvent)
+}
 
 /// Protocol representing a view model type, acting as the business logic layer above a `Model` and providing the
 /// necessary data and methods for `View` binding.
@@ -16,230 +45,37 @@ import Foundation
 /// binding step.
 ///
 /// Ideally, view models should be value-types, but may be reference-types if identity/state is required.
-public protocol ViewModel {
-
+public protocol ViewModel: ViewModelType {
     init(model: Model, context: Context)
-
-    /// Access to the underlying `Context`.
-    var context: Context { get }
-
-    // MARK: Interactions
-
-    /// Returns the `Action` that should be fired for a given `ViewModelUserEvent`. The default implementation returns
-    /// nil.
-    func action(_ event: ViewModelUserEvent) -> Action?
-
-    /// Returns `true` if the target view model type can handle the given user event, `false` if it cannot. The default
-    /// implementation calls action(_:) passing in the event and returns `true` if the function returns a non-nil
-    /// action.
-    func canHandleUserEvent(_ event: ViewModelUserEvent) -> Bool
-
-    /// Invoked on the view model when the view layer wants it to handle a given user event. The default implementation
-    /// sends the action from action(_:) to the context. For most usecases implementing this is unnecessary.
-    func handleUserEvent(_ event: ViewModelUserEvent)
-
-    // MARK: Actions
-
-    /// An array of secondary actions - typically displayed as a context menu or long-press menu depending on platform.
-    func secondaryActions(for event: ViewModelUserEvent) -> [SecondaryAction]
 }
 
-/// Wraps an `Action` with additional data to be rendered in a "secondary" context like context menus or long-press
-/// menus.
-public struct SecondaryActionInfo {
-    public struct Metadata {
-        public let title: String
-        public let state: State
-        public let enabled: Bool
-        public let imageName: String?
-        public let keyEquivalent: String
-
-        /// State of the secondary action. Note that this differs from enabled, but instead represents whether the
-        /// action is "checked" in a list.
-        public enum State: ExpressibleByBooleanLiteral {
-            case on
-            case off
-            case mixed
-
-            public init(booleanLiteral value: BooleanLiteralType) {
-                if value {
-                    self = .on
-                } else {
-                    self = .off
-                }
-            }
-        }
-
-        // Always provide a default value, so that it is easy to create partial Metadata to overlay on top on an
-        // existing item. For example, an AppActionResponder may want to pass up Metadata(state: .on) to add
-        // a checkmark to an item, without knowing the exact name of the action.
-        public init(
-            title: String = "",
-            state: Metadata.State = .off,
-            enabled: Bool = true,
-            imageName: String? = nil,
-            keyEquivalent: String = ""
-        ) {
-            self.title = title
-            self.state = state
-            self.enabled = enabled
-            self.imageName = imageName
-            self.keyEquivalent = keyEquivalent
-        }
-
-        // Enforce some common conventions (for example, state is off, no keyEquivalent).
-        public static func forNestedActions(
-            title: String,
-            enabled: Bool = true,
-            imageName: String? = nil
-        ) -> Metadata {
-            return Metadata(title: title, state: .off, enabled: enabled, imageName: imageName)
-        }
-    }
-
-    public init(metadata: Metadata, action: Action) {
-        self.metadata = metadata
-        self.action = action
-    }
-
-    public let metadata: Metadata
-    public let action: Action
-}
-
-/// Describes a group of nested SecondaryActions.
-public struct NestedActionsInfo {
-    public init(metadata: SecondaryActionInfo.Metadata, actions: [SecondaryAction]) {
-        self.metadata = metadata
-        self.actions = actions
-    }
-
-    public let metadata: SecondaryActionInfo.Metadata
-    public let actions: [SecondaryAction]
-}
-
-/// Represents a secondary action to be displayed in a list to the user (typically from right-click or long-press).
-public enum SecondaryAction {
-    case action(SecondaryActionInfo)
-    case info(String)
-    case separator
-    case nested(NestedActionsInfo)
+/// Protocol representing a collection of one or more view models that respresent a user selection and can provide
+/// customizable handling of user actions based on the selection and context.
+public protocol SelectionViewModel: ViewModelType {
+    /// Initialize with a collection of view models.
+    init(viewModels: [ViewModel], context: Context)
 }
 
 /// Default implementations so `ViewModel`s may opt-in to only interactions they care about.
-public extension ViewModel {
+public extension ViewModelType {
 
-    func action(_ event: ViewModelUserEvent) -> Action? {
+    func actionForUserEvent(_ event: ViewModelUserEvent) -> Action? {
         return nil
     }
 
     func handleUserEvent(_ event: ViewModelUserEvent) {
-        action(event)?.send(from: context)
+        actionForUserEvent(event)?.send(from: context)
     }
 
     func canHandleUserEvent(_ event: ViewModelUserEvent) -> Bool {
-        return action(event) != nil
+        if .secondaryClick == event {
+            return !secondaryActions(for: event).isEmpty
+        } else {
+            return actionForUserEvent(event) != nil
+        }
     }
 
     func secondaryActions(for event: ViewModelUserEvent) -> [SecondaryAction] {
         return []
     }
-}
-
-// MARK: Binding
-
-/// An optional protocol that types may adopt in order to provide a `ViewModel` directly. This is the default method
-/// `ViewModelBindingProvider` uses to instantiate a `ViewModel`.
-public protocol ViewModelConvertible {
-
-    /// Return a `ViewModel` representing the target type.
-    func viewModelWithContext(_ context: Context) -> ViewModel
-}
-
-/// Core binding provider protocol to generate `ViewModel` instances from `Model` instances.
-public protocol ViewModelBindingProvider {
-
-    /// Returns a `ViewModel` for the given `Model` and context.
-    func viewModel(for model: Model, context: Context) -> ViewModel
-
-    /// Returns the `SelectionViewModel` for given collection of models and a context. The default implementation
-    /// returns selection view model that works for a single model.
-    func selectionViewModel(for models: [Model], context: Context) -> SelectionViewModel?
-}
-
-extension ViewModelBindingProvider {
-    public func selectionViewModel(for models: [Model], context: Context) -> SelectionViewModel? {
-        if let firstModel = models.first, models.count == 1 {
-            return ViewModelSelectionShim(viewModels: [viewModel(for: firstModel, context: context)])
-        }
-        return nil
-    }
-}
-
-/// Represents a selection of one or more view models.
-public protocol SelectionViewModel {
-    /// Initialize with a collection of view models.
-    init(viewModels: [ViewModel])
-    /// Returns `true` if the selection can handle the given user event, `false` if it cannot.
-    func canHandleUserEvent(_ event: ViewModelUserEvent) -> Bool
-    /// Invoked on the selection when the view layer wants it to handle a given user event.
-    func handleUserEvent(_ event: ViewModelUserEvent)
-    /// An array of secondary actions for the selection - typically displayed as a context menu or long-press menu
-    /// depending on platform.
-    func secondaryActions(for event: ViewModelUserEvent) -> [SecondaryAction]
-}
-
-/// A `ViewModelBindingProvider` which provides default behavior to check the `Model` for conformance to
-/// `ViewModelConvertible`.
-public struct DefaultViewModelBindingProvider: ViewModelBindingProvider {
-
-    public init() {}
-
-    // MARK: ViewModelBindingProvider
-
-    public func viewModel(for model: Model, context: Context) -> ViewModel {
-        guard let convertible = model as? ViewModelConvertible else {
-            // Programmer error to fail to provide a binding.
-            // - TODO:(wkiefer) Avoid `fatalError` for programmer binding errors - return default empty views & assert.
-            fatalError(
-                "Default ViewModel binding requires model to conform to `ViewModelConvertible`: \(type(of: model))")
-        }
-        return convertible.viewModelWithContext(context)
-    }
-}
-
-/// A `ViewModelBindingProvider` that delegates to a closure to provide the appropriate `ViewModel` for the
-/// supplied `Model` and `Context`. It will fallback to the `DefaultViewModelBindingProvider` implementation
-/// if no `ViewModel` is returned.
-public struct BlockViewModelBindingProvider: ViewModelBindingProvider {
-    public init(binder: @escaping (Model, Context) -> ViewModel?) {
-        self.binder = binder
-    }
-
-    public func viewModel(for model: Model, context: Context) -> ViewModel {
-        return self.binder(model, context) ?? DefaultViewModelBindingProvider().viewModel(for: model, context: context)
-    }
-
-    private let binder: (Model, Context) -> ViewModel?
-}
-
-/// Simple shim that forwards methods from `SelectionViewModel` to a single `ViewModel`.
-fileprivate struct ViewModelSelectionShim: SelectionViewModel {
-    init(viewModels: [ViewModel]) {
-        guard let vm = viewModels.first else { fatalError("Shim constructed with empty view model collection") }
-        self.viewModel = vm
-    }
-
-    func canHandleUserEvent(_ event: ViewModelUserEvent) -> Bool {
-        return viewModel.canHandleUserEvent(event)
-    }
-
-    func handleUserEvent(_ event: ViewModelUserEvent) {
-        return viewModel.handleUserEvent(event)
-    }
-
-    func secondaryActions(for event: ViewModelUserEvent) -> [SecondaryAction] {
-        return viewModel.secondaryActions(for: event)
-    }
-
-    var viewModel: ViewModel
 }

--- a/Core/Source/MVVM/ViewModelBinding.swift
+++ b/Core/Source/MVVM/ViewModelBinding.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// An optional protocol that types may adopt in order to provide a `ViewModel` directly. This is the default method
+/// `ViewModelBindingProvider` uses to instantiate a `ViewModel`.
+public protocol ViewModelConvertible {
+
+    /// Return a `ViewModel` representing the target type.
+    func viewModelWithContext(_ context: Context) -> ViewModel
+}
+
+/// Core binding provider protocol to generate `ViewModel` instances from `Model` instances.
+public protocol ViewModelBindingProvider {
+
+    /// Returns a `ViewModel` for the given `Model` and context.
+    func viewModel(for model: Model, context: Context) -> ViewModel
+
+    /// Returns the `SelectionViewModel` for given collection of models and a context. The default implementation
+    /// returns selection view model that works for a single model.
+    func selectionViewModel(for models: [Model], context: Context) -> SelectionViewModel?
+}
+
+extension ViewModelBindingProvider {
+    public func selectionViewModel(for models: [Model], context: Context) -> SelectionViewModel? {
+        if let firstModel = models.first, models.count == 1 {
+            let firstViewModel = viewModel(for: firstModel, context: context)
+            return ViewModelSelectionShim(viewModels: [firstViewModel], context: context)
+        }
+        return nil
+    }
+}
+
+/// A `ViewModelBindingProvider` which provides default behavior to check the `Model` for conformance to
+/// `ViewModelConvertible`.
+public struct DefaultViewModelBindingProvider: ViewModelBindingProvider {
+
+    public init() {}
+
+    // MARK: ViewModelBindingProvider
+
+    public func viewModel(for model: Model, context: Context) -> ViewModel {
+        guard let convertible = model as? ViewModelConvertible else {
+            // Programmer error to fail to provide a binding.
+            // - TODO:(wkiefer) Avoid `fatalError` for programmer binding errors - return default empty views & assert.
+            fatalError(
+                "Default ViewModel binding requires model to conform to `ViewModelConvertible`: \(type(of: model))")
+        }
+        return convertible.viewModelWithContext(context)
+    }
+}
+
+/// A `ViewModelBindingProvider` that delegates to a closure to provide the appropriate `ViewModel` for the
+/// supplied `Model` and `Context`. It will fallback to the `DefaultViewModelBindingProvider` implementation
+/// if no `ViewModel` is returned.
+public struct BlockViewModelBindingProvider: ViewModelBindingProvider {
+    public init(binder: @escaping (Model, Context) -> ViewModel?) {
+        self.binder = binder
+    }
+
+    public func viewModel(for model: Model, context: Context) -> ViewModel {
+        return self.binder(model, context) ?? DefaultViewModelBindingProvider().viewModel(for: model, context: context)
+    }
+
+    private let binder: (Model, Context) -> ViewModel?
+}
+
+/// Simple shim that forwards methods from `SelectionViewModel` to a single `ViewModel`.
+fileprivate struct ViewModelSelectionShim: SelectionViewModel {
+    init(viewModels: [ViewModel], context: Context) {
+        guard let vm = viewModels.first else { fatalError("Shim constructed with empty view model collection") }
+        self.context = context
+        self.viewModel = vm
+    }
+
+    var context: Context
+    var viewModel: ViewModel
+
+    // MARK: ViewModelType
+
+    func canHandleUserEvent(_ event: ViewModelUserEvent) -> Bool {
+        return viewModel.canHandleUserEvent(event)
+    }
+
+    func handleUserEvent(_ event: ViewModelUserEvent) {
+        return viewModel.handleUserEvent(event)
+    }
+
+    func secondaryActions(for event: ViewModelUserEvent) -> [SecondaryAction] {
+        return viewModel.secondaryActions(for: event)
+    }
+}

--- a/Examples/iTunesSearch/Shared/PodcastViewModel.swift
+++ b/Examples/iTunesSearch/Shared/PodcastViewModel.swift
@@ -24,10 +24,11 @@ public struct PodcastViewModel: ViewModel {
 
     public let context: Context
 
-    public func handleUserEvent(_ event: ViewModelUserEvent) {
+    public func handleUserEvent(_ event: ViewModelUserEvent) -> Action? {
         if case .select = event {
-            ViewURLAction(url: podcast.collectionView).send(from: context)
+            return ViewURLAction(url: podcast.collectionView)
         }
+        return nil
     }
 
     // MARK: Private

--- a/Examples/iTunesSearch/Shared/PodcastViewModel.swift
+++ b/Examples/iTunesSearch/Shared/PodcastViewModel.swift
@@ -24,7 +24,7 @@ public struct PodcastViewModel: ViewModel {
 
     public let context: Context
 
-    public func handleUserEvent(_ event: ViewModelUserEvent) -> Action? {
+    public func actionForUserEvent(_ event: ViewModelUserEvent) -> Action? {
         if case .select = event {
             return ViewURLAction(url: podcast.collectionView)
         }

--- a/Examples/iTunesSearch/Shared/SongViewModel.swift
+++ b/Examples/iTunesSearch/Shared/SongViewModel.swift
@@ -50,10 +50,11 @@ public struct SongViewModel: ViewModel {
 
     public let context: Context
 
-    public func handleUserEvent(_ event: ViewModelUserEvent) {
+    public func action(_ event: ViewModelUserEvent) -> Action? {
         if case .select = event {
-            ViewMediaAction(url: song.preview).send(from: context)
+            return ViewMediaAction(url: song.preview)
         }
+        return nil
     }
 
     // MARK: Private

--- a/Examples/iTunesSearch/Shared/SongViewModel.swift
+++ b/Examples/iTunesSearch/Shared/SongViewModel.swift
@@ -50,7 +50,7 @@ public struct SongViewModel: ViewModel {
 
     public let context: Context
 
-    public func action(_ event: ViewModelUserEvent) -> Action? {
+    public func actionForUserEvent(_ event: ViewModelUserEvent) -> Action? {
         if case .select = event {
             return ViewMediaAction(url: song.preview)
         }

--- a/Examples/iTunesSearch/Shared/TelevisionEpisodeViewModel.swift
+++ b/Examples/iTunesSearch/Shared/TelevisionEpisodeViewModel.swift
@@ -32,10 +32,11 @@ public struct TelevisionEpisodeViewModel: ViewModel {
 
     public let context: Context
 
-    public func handleUserEvent(_ event: ViewModelUserEvent) {
+    public func action(_ event: ViewModelUserEvent) -> Action? {
         if case .select = event {
-            ViewMediaAction(url: episode.preview).send(from: context)
+            return ViewMediaAction(url: episode.preview)
         }
+        return nil
     }
 
     // MARK: Private

--- a/Examples/iTunesSearch/Shared/TelevisionEpisodeViewModel.swift
+++ b/Examples/iTunesSearch/Shared/TelevisionEpisodeViewModel.swift
@@ -32,7 +32,7 @@ public struct TelevisionEpisodeViewModel: ViewModel {
 
     public let context: Context
 
-    public func action(_ event: ViewModelUserEvent) -> Action? {
+    public func actionForUserEvent(_ event: ViewModelUserEvent) -> Action? {
         if case .select = event {
             return ViewMediaAction(url: episode.preview)
         }

--- a/Examples/iTunesSearch/SongViewModelTests.swift
+++ b/Examples/iTunesSearch/SongViewModelTests.swift
@@ -37,7 +37,7 @@ class SongViewModelTests: XCTestCase {
         let song = stubSong
         let context = Context()
         let subject = SongViewModel(model: song, context: context)
-        let result = subject.action(.select)
+        let result = subject.actionForUserEvent(.select)
         if let result = result as? ViewMediaAction {
             XCTAssertEqual(result.url, song.preview)
         } else {

--- a/Examples/iTunesSearch/SongViewModelTests.swift
+++ b/Examples/iTunesSearch/SongViewModelTests.swift
@@ -36,19 +36,13 @@ class SongViewModelTests: XCTestCase {
     func testSelectionEmitsAViewMediaAction() {
         let song = stubSong
         let context = Context()
-        var contextReceivedAction = false
-        _ = context.addReceiver({ (action) -> ActionResult in
-            if let a = action as? ViewMediaAction {
-                XCTAssertEqual(a.url, song.preview)
-            } else {
-                XCTFail("Received unexpected action: \(action)")
-            }
-            contextReceivedAction = true
-            return .handled
-        })
         let subject = SongViewModel(model: song, context: context)
-        subject.handleUserEvent(.select)
-        XCTAssertTrue(contextReceivedAction, "Context should receive an action")
+        let result = subject.action(.select)
+        if let result = result as? ViewMediaAction {
+            XCTAssertEqual(result.url, song.preview)
+        } else {
+            XCTFail("Expected a 'ViewMediaAction' for .select events. Got \(String(describing: result)).")
+        }
     }
 }
 

--- a/Pilot.xcodeproj/project.pbxproj
+++ b/Pilot.xcodeproj/project.pbxproj
@@ -113,6 +113,10 @@
 		8E0E6F261EE8951500D1CB86 /* SortedModelCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E0E6F241EE894FD00D1CB86 /* SortedModelCollection.swift */; };
 		8E0E6F281EE89A3D00D1CB86 /* SortedModelCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E0E6F271EE89A3D00D1CB86 /* SortedModelCollectionTests.swift */; };
 		8E0E6F291EE89A3D00D1CB86 /* SortedModelCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E0E6F271EE89A3D00D1CB86 /* SortedModelCollectionTests.swift */; };
+		A428996E1FA137F300EA4422 /* SecondaryActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A428996D1FA137F300EA4422 /* SecondaryActionInfo.swift */; };
+		A428996F1FA137F300EA4422 /* SecondaryActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A428996D1FA137F300EA4422 /* SecondaryActionInfo.swift */; };
+		A42899711FA1393500EA4422 /* ViewModelBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42899701FA1393500EA4422 /* ViewModelBinding.swift */; };
+		A42899721FA1393500EA4422 /* ViewModelBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42899701FA1393500EA4422 /* ViewModelBinding.swift */; };
 		A437EDA81E56507600F67B37 /* SimpleModelCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A437EDA71E56507600F67B37 /* SimpleModelCollection.swift */; };
 		A437EDA91E56507600F67B37 /* SimpleModelCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A437EDA71E56507600F67B37 /* SimpleModelCollection.swift */; };
 		A437EDAB1E5655AD00F67B37 /* SimpleModelCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A437EDAA1E5655AD00F67B37 /* SimpleModelCollection.swift */; };
@@ -271,6 +275,8 @@
 		69FADC931D30BDC2001F2E11 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/AppKit.framework; sourceTree = DEVELOPER_DIR; };
 		8E0E6F241EE894FD00D1CB86 /* SortedModelCollection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SortedModelCollection.swift; path = Core/Source/MVVM/SortedModelCollection.swift; sourceTree = "<group>"; };
 		8E0E6F271EE89A3D00D1CB86 /* SortedModelCollectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SortedModelCollectionTests.swift; path = Core/Tests/MVVM/SortedModelCollectionTests.swift; sourceTree = "<group>"; };
+		A428996D1FA137F300EA4422 /* SecondaryActionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SecondaryActionInfo.swift; path = Core/Source/MVVM/SecondaryActionInfo.swift; sourceTree = "<group>"; };
+		A42899701FA1393500EA4422 /* ViewModelBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ViewModelBinding.swift; path = Core/Source/MVVM/ViewModelBinding.swift; sourceTree = "<group>"; };
 		A437EDA71E56507600F67B37 /* SimpleModelCollection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SimpleModelCollection.swift; path = Core/Tests/MVVM/SimpleModelCollection.swift; sourceTree = "<group>"; };
 		A437EDAA1E5655AD00F67B37 /* SimpleModelCollection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SimpleModelCollection.swift; path = Core/Source/MVVM/SimpleModelCollection.swift; sourceTree = "<group>"; };
 		A437EDAD1E5660CE00F67B37 /* AsyncModelCollection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AsyncModelCollection.swift; path = Core/Source/MVVM/AsyncModelCollection.swift; sourceTree = "<group>"; };
@@ -577,6 +583,7 @@
 				69F89E741C52F06200F08E28 /* ModelCollection.swift */,
 				D5DF48131CAAC2F200F611E6 /* MultiplexModelCollection.swift */,
 				022120341DFB807C007C4039 /* ScoredModelCollection.swift */,
+				A428996D1FA137F300EA4422 /* SecondaryActionInfo.swift */,
 				A437EDAA1E5655AD00F67B37 /* SimpleModelCollection.swift */,
 				8E0E6F241EE894FD00D1CB86 /* SortedModelCollection.swift */,
 				698F3F7E1CE543DB00076B8C /* StaticModel.swift */,
@@ -586,6 +593,7 @@
 				69F89E781C52F06200F08E28 /* View.swift */,
 				693A60C91CAC80F800E0D2A3 /* ViewLayout.swift */,
 				69F89E771C52F06200F08E28 /* ViewModel.swift */,
+				A42899701FA1393500EA4422 /* ViewModelBinding.swift */,
 				A4897B621F95582100727514 /* ViewModelUserEvents.swift */,
 			);
 			name = MVVM;
@@ -996,6 +1004,7 @@
 				69AECEF71CAB07FF00EEE780 /* FilteredModelCollection.swift in Sources */,
 				0263D8081D6CCE6C0042415E /* StaticModelCollection.swift in Sources */,
 				02AADF511D6E433E00587167 /* SwitchableModelCollection.swift in Sources */,
+				A428996F1FA137F300EA4422 /* SecondaryActionInfo.swift in Sources */,
 				A4AED3D61D402D73001F3524 /* MappedModelCollection.swift in Sources */,
 				6988476B1CE6459B0075D205 /* StaticViewBindingProvider.swift in Sources */,
 				8E0E6F261EE8951500D1CB86 /* SortedModelCollection.swift in Sources */,
@@ -1006,6 +1015,7 @@
 				A437EDB61E567AE900F67B37 /* Async.swift in Sources */,
 				A460CC841E56195F00F9AC6F /* Downcast.swift in Sources */,
 				A4897B641F95582100727514 /* ViewModelUserEvents.swift in Sources */,
+				A42899721FA1393500EA4422 /* ViewModelBinding.swift in Sources */,
 				698F3F7F1CE543DB00076B8C /* StaticModel.swift in Sources */,
 				69F89E791C52F06200F08E28 /* ModelCollection.swift in Sources */,
 				D560D4611D136E11000DA826 /* ConsoleLogger.swift in Sources */,
@@ -1107,6 +1117,7 @@
 				696534A21D1710D400DF97CB /* FilteredModelCollection.swift in Sources */,
 				6965349F1D1710CB00DF97CB /* Logger.swift in Sources */,
 				02AADF501D6E433E00587167 /* SwitchableModelCollection.swift in Sources */,
+				A428996E1FA137F300EA4422 /* SecondaryActionInfo.swift in Sources */,
 				696534A11D1710D400DF97CB /* EmptyModelCollection.swift in Sources */,
 				A4AED3D51D402D73001F3524 /* MappedModelCollection.swift in Sources */,
 				8E0E6F251EE894FD00D1CB86 /* SortedModelCollection.swift in Sources */,
@@ -1117,6 +1128,7 @@
 				A437EDB51E567AE800F67B37 /* Async.swift in Sources */,
 				696534AB1D1710D400DF97CB /* View.swift in Sources */,
 				A4897B631F95582100727514 /* ViewModelUserEvents.swift in Sources */,
+				A42899711FA1393500EA4422 /* ViewModelBinding.swift in Sources */,
 				022862581DB0070100FCD03F /* DiffEngine.swift in Sources */,
 				692936111E130468001303D2 /* Action.swift in Sources */,
 				696534A41D1710D400DF97CB /* Context.swift in Sources */,


### PR DESCRIPTION
_Context: This is a much lower-urgency pull, I just happened to notice this pattern emerge today and wanted to share while it was fresh_

Currently ViewModels implement all of their "behavior" (outside of getters at least) through `handleUserEvent(_:)`. Unfortunately this function actually ... _handles_ (the user event), typically by creating an action in response to the user event and sending it to its `context` object. Because this is imperative, it becomes a difficult place to perform unit testing. Needing to create a mock context something like in the iTunes example:

```
let song = stubSong
let context = Context()
var contextReceivedAction = false		
_ = context.addReceiver({ (action) -> ActionResult in		
    if let a = action as? ViewMediaAction {		
        XCTAssertEqual(a.url, song.preview)		
    } else {		
        XCTFail("Received unexpected action: \(action)")		
    }		
    contextReceivedAction = true		
    return .handled		
})		
let subject = SongViewModel(model: song, context: context)
subject.handleUserEvent(.select)
XCTAssertTrue(contextReceivedAction, "Context should receive an action")
```

Instead this diff proposes that ViewModels simply return the action they want to perform for a given user event in `action(_:)` and then the default implementation of view model's `handleUserEvent(_:)` can simply call that function and send it along to the context. This makes testing as easy as checking the value from the action(_:) function

```
let result = subject.action(.select) as? ViewMediaAction
XCTAssertEqual(result?.url, song.preview)
```

Also gives us a meaningful implementation of `canHandleUserEvent` for free, which is especially valuable when handling keyboard events (#78) since you'll almost always want that logic to be shared.

The real question is whether or not to even expose handleUserEvent (or canHandleUserEvent for that matter)? 

I left them in in this diff, which would allow app developers to override to perform non-action side-effects as needed. But as far as I can doing a quick audit of $MAIN_APP_WERE_WORKING_ON, none of our view models do this, and I'm not sure I can think of a non-bad idea for a time to use it. Curious what you think?