### PR TITLE
Support "ZeroItem" in custom supplementary views

### DIFF
--- a/UI/Source/CollectionViews/CollectionViewModelDataSource.swift
+++ b/UI/Source/CollectionViews/CollectionViewModelDataSource.swift
@@ -409,6 +409,14 @@ public class CollectionViewModelDataSource: NSObject, ProxyingObservable {
     fileprivate func viewModelForSupplementaryElementAtIndexPath(_ kind: String, indexPath: IndexPath) -> ViewModel {
         let model = modelForSupplementaryIndexPath(indexPath, ofKind: kind)
         if let bindingProvider = supplementaryViewModelBinderMap[kind] {
+            // Supplementary items don't necessarily have an item associated with them (think section headers for empty
+            // sections) - so handle the "zero" case here.
+            if let zeroModel = model as? CollectionZeroItemModel {
+                return CachedViewModel(
+                    viewModel: CollectionZeroItemViewModel(indexPath: zeroModel.indexPath),
+                    preferredLayout: .none).viewModel
+            }
+
             return bindingProvider.viewModel(for: model, context: context)
         } else {
             return cachedViewModel(for: model).viewModel


### PR DESCRIPTION
Currently in the default view model provider the data source provides a CollectionZeroItemViewModel when it encounters a CollectionZeroItemModel. This wasn't the case if the implementor provides a custom view model binding provider leaving it to implement the exact same "empty" pieces itself (The CollectionZeroItemViewModel is internal to Pilot).

This code just uses the same logic as the primary path to shortcut CollectionZeroItemModels and return a CollectionZeroItemViewModel.