### PR TITLE
Add "block" providers for Models and ViewModels

### DIFF
--- a/Core/Source/MVVM/ModelCollection.swift
+++ b/Core/Source/MVVM/ModelCollection.swift
@@ -166,10 +166,7 @@ public struct BlockModelProvider: IndexedModelProvider {
     }
 
     public func model(for indexPath: IndexPath, context: Context) -> Model? {
-        if let result = binder(indexPath, context) {
-            return result
-        }
-        return nil
+        return binder(indexPath, context)
     }
 
     private let binder: (IndexPath, Context) -> Model?

--- a/Core/Source/MVVM/ModelCollection.swift
+++ b/Core/Source/MVVM/ModelCollection.swift
@@ -158,6 +158,23 @@ public protocol IndexedModelProvider {
     func model(for indexPath: IndexPath, context: Context) -> Model?
 }
 
+/// An `IndexedModelProvider` implementation that delegates to a closure to provide the
+/// appropriate model for the supplied `IndexPath` and `Context`.
+public struct BlockModelProvider: IndexedModelProvider {
+    public init(binder: @escaping (IndexPath, Context) -> Model?) {
+        self.binder = binder
+    }
+
+    public func model(for indexPath: IndexPath, context: Context) -> Model? {
+        if let result = binder(indexPath, context) {
+            return result
+        }
+        return nil
+    }
+
+    private let binder: (IndexPath, Context) -> Model?
+}
+
 // MARK: ModelCollection
 
 /// Generic protocol defining a collection of `Model` items grouped into sections. This is the core Pilot

--- a/Core/Source/MVVM/ViewModel.swift
+++ b/Core/Source/MVVM/ViewModel.swift
@@ -143,3 +143,18 @@ public struct DefaultViewModelBindingProvider: ViewModelBindingProvider {
         return convertible.viewModelWithContext(context)
     }
 }
+
+/// A `ViewModelBindingProvider` that delegates to a closure to provide the appropriate `ViewModel` for the
+/// supplied `Model` and `Context`. It will fallback to the `DefaultViewModelBindingProvider` implementation
+/// if no `ViewModel` is returned.
+public struct BlockViewModelBindingProvider: ViewModelBindingProvider {
+    public init(binder: @escaping (Model, Context) -> ViewModel?) {
+        self.binder = binder
+    }
+
+    public func viewModel(for model: Model, context: Context) -> ViewModel {
+        return self.binder(model, context) ?? DefaultViewModelBindingProvider().viewModel(for: model, context: context)
+    }
+
+    private let binder: (Model, Context) -> ViewModel?
+}


### PR DESCRIPTION
I've found these to be useful implementing supplementary views as it allows you to quickly define a provider without all the boilerplate.

```swift
dataSource.setModelProvider(
    provider: BlockModelProvider { FileActivity(...) },
    forSupplementaryElementOfKind: FileActivityViewIdentifier)

dataSource.setViewModelBinder(
    BlockViewModelProvider { FileActivityBadgeViewModel(model: $0, context: $1) },
    forSupplementaryElementOfKind: FileActivityViewIdentifier)
```

I also wondered about providing some sugar by extending the base protocols so you can do something like:

```swift
dataSource.setModelProvider(
    provider: .using { FileActivity(...) },
    forSupplementaryElementOfKind: FileActivityViewIdentifier)
```

But I think I'll leave that for the moment.