### PR TITLE
Copy action support

### DIFF
--- a/Core/Source/MVVM/ViewModel.swift
+++ b/Core/Source/MVVM/ViewModel.swift
@@ -78,12 +78,12 @@ public extension ViewModel {
 
     func handleUserEvent(_ event: ViewModelUserEvent) {}
 
-    /// By default returns true for all non-keyboard events.
+    /// By default returns true for all non-keyboard and pasteboard events.
     func canHandleUserEvent(_ event: ViewModelUserEvent) -> Bool {
-        if case .keyDown = event {
-            return false
+        switch event {
+        case .click, .longPress, .secondaryClick, .select, .tap: return true
+        case .keyDown, .copy: return false
         }
-        return true
     }
 
     func secondaryActions(for event: ViewModelUserEvent) -> [SecondaryAction] {

--- a/Core/Source/MVVM/ViewModelUserEvents.swift
+++ b/Core/Source/MVVM/ViewModelUserEvents.swift
@@ -19,6 +19,9 @@ public enum ViewModelUserEvent {
 
     /// On touch platforms, represents the target receiving a single tap.
     case tap
+
+    /// Represents the user attempting to copy the view model to the pasteboard.
+    case copy
 }
 
 /// Simple wrapper around NSEvent.ModifierFlags to avoid importing AppKit.
@@ -63,17 +66,19 @@ extension ViewModelUserEvent: Hashable {
             return 1<<3
         case .tap:
             return 1<<4
+        case .copy:
+            return 1<<5
         }
     }
 
     public static func ==(lhs: ViewModelUserEvent, rhs: ViewModelUserEvent) -> Bool {
         switch (lhs, rhs) {
         case (.click, .click), (.longPress, .longPress), (.secondaryClick, .secondaryClick), (.select, .select),
-             (.tap, .tap):
+             (.tap, .tap), (.copy, .copy):
             return true
         case (.keyDown(let lKey, let lModifiers), .keyDown(let rKey, let rModifiers)):
             return lKey == rKey && lModifiers == rModifiers
-        case (.click, _), (.longPress, _), (.secondaryClick, _), (.select, _), (.tap, _), (.keyDown, _):
+        case (.click, _), (.longPress, _), (.secondaryClick, _), (.select, _), (.tap, _), (.keyDown, _), (.copy, _):
             return false
         }
     }

--- a/UI/Source/CollectionViews/mac/CollectionViewController.swift
+++ b/UI/Source/CollectionViews/mac/CollectionViewController.swift
@@ -216,6 +216,18 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
         lastBounds = bounds
     }
 
+    @objc
+    private func copy(_ sender: Any) {
+        selectedViewModel()?.handleUserEvent(.copy)
+    }
+
+    open override func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+        if menuItem.action == #selector(copy(_:)) {
+            return selectedViewModel()?.canHandleUserEvent(.copy) == true
+        }
+        return false
+    }
+
     // MARK: CollectionViewDelegate
 
     open func collectionViewDidReceiveKeyEvent(
@@ -223,8 +235,7 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
         key: EventKeyCode,
         modifiers: AppKitEventModifierFlags
     ) -> Bool {
-        guard let indexPath = collectionView.selectionIndexPaths.first else { return false }
-        guard let vm = viewModelAtIndexPath(indexPath) else { return false }
+        guard let vm = selectedViewModel() else { return false }
         let event = ViewModelUserEvent.keyDown(key, modifiers.eventKeyModifierFlags)
         if vm.canHandleUserEvent(event) {
             vm.handleUserEvent(event)
@@ -384,6 +395,12 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
         guard let menuNotificationObserver = self.menuNotificationObserver else { return }
         NotificationCenter.default.removeObserver(menuNotificationObserver)
         self.menuNotificationObserver = nil
+    }
+
+    private func selectedViewModel() -> ViewModel? {
+        guard let indexPath = collectionView.selectionIndexPaths.first else { return nil }
+        guard let vm = viewModelAtIndexPath(indexPath) else { return nil }
+        return vm
     }
 
     // MARK: Observing model state changes.

--- a/UI/Source/CollectionViews/mac/CollectionViewController.swift
+++ b/UI/Source/CollectionViews/mac/CollectionViewController.swift
@@ -396,8 +396,7 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
 
     private func selectedViewModel() -> ViewModel? {
         guard let indexPath = collectionView.selectionIndexPaths.first else { return nil }
-        guard let vm = viewModelAtIndexPath(indexPath) else { return nil }
-        return vm
+        return viewModelAtIndexPath(indexPath)
     }
 
     @objc

--- a/UI/Source/CollectionViews/mac/CollectionViewController.swift
+++ b/UI/Source/CollectionViews/mac/CollectionViewController.swift
@@ -216,18 +216,6 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
         lastBounds = bounds
     }
 
-    @objc
-    private func copy(_ sender: Any) {
-        selectedViewModel()?.handleUserEvent(.copy)
-    }
-
-    open override func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
-        if menuItem.action == #selector(copy(_:)) {
-            return selectedViewModel()?.canHandleUserEvent(.copy) == true
-        }
-        return false
-    }
-
     // MARK: CollectionViewDelegate
 
     open func collectionViewDidReceiveKeyEvent(
@@ -290,6 +278,15 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
         if vm.canHandleUserEvent(.select) {
             vm.handleUserEvent(.select)
         }
+    }
+
+    // MARK: NSObject
+
+    open override func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+        if menuItem.action == #selector(copy(_:)) {
+            return selectedViewModel()?.canHandleUserEvent(.copy) == true
+        }
+        return false
     }
 
     // MARK: Private
@@ -401,6 +398,11 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
         guard let indexPath = collectionView.selectionIndexPaths.first else { return nil }
         guard let vm = viewModelAtIndexPath(indexPath) else { return nil }
         return vm
+    }
+
+    @objc
+    private func copy(_ sender: Any) {
+        selectedViewModel()?.handleUserEvent(.copy)
     }
 
     // MARK: Observing model state changes.


### PR DESCRIPTION
Lets ViewModels handle a generic copy action by just overriding canHandleUserEvent + handleUserEvent and the CollectionViewController enables/disables the menu item automatically.