### PR TITLE
 SecondaryActionInfo.Metadata update.

### DIFF
--- a/Core/Source/MVVM/ViewModel.swift
+++ b/Core/Source/MVVM/ViewModel.swift
@@ -41,44 +41,58 @@ public protocol ViewModel {
 /// Wraps an `Action` with additional data to be rendered in a "secondary" context like context menus or long-press
 /// menus.
 public struct SecondaryActionInfo {
+    public struct Metadata {
+        public let title: String
+        public let state: State
+        public let enabled: Bool
+        public let imageName: String?
+        public let keyEquivalent: String
 
-    public init(action: Action, title: String, state: State = .off, enabled: Bool = true, imageName: String? = nil) {
-        self.action = action
-        self.title = title
-        self.state = state
-        self.enabled = enabled
-        self.imageName = imageName
+        /// State of the secondary action. Note that this differs from enabled, but instead represents whether the
+        /// action is "checked" in a list.
+        public enum State {
+            case on
+            case off
+            case mixed
+        }
     }
 
-    /// State of the secondary action. Note that this differs from enabled, but instead represents whether the action
-    /// is "checked" in a list.
-    public enum State {
-        case on
-        case off
-        case mixed
+    public init(
+        action: Action,
+        title: String,
+        state: Metadata.State = .off,
+        enabled: Bool = true,
+        imageName: String? = nil,
+        keyEquivalent: String = ""
+        ) {
+        self.action = action
+        self.metadata = Metadata(
+            title: title,
+            state: state,
+            enabled: enabled,
+            imageName: imageName,
+            keyEquivalent: keyEquivalent)
     }
 
     public let action: Action
-    public let title: String
-    public let state: State
-    public let enabled: Bool
-    public let imageName: String?
+    public let metadata: Metadata
 }
 
 /// Describes a group of nested SecondaryActions.
 public struct NestedActionsInfo {
 
     public init(title: String, enabled: Bool = true, imageName: String? = nil, actions: [SecondaryAction]) {
-        self.title = title
-        self.enabled = enabled
-        self.imageName = imageName
+        self.metadata = SecondaryActionInfo.Metadata(
+            title: title,
+            state: .off,
+            enabled: enabled,
+            imageName: imageName,
+            keyEquivalent: "")
         self.actions = actions
     }
 
-    public let title: String
-    public let enabled: Bool
-    public let imageName: String?
     public let actions: [SecondaryAction]
+    public let metadata: SecondaryActionInfo.Metadata
 }
 
 /// Represents a secondary action to be displayed in a list to the user (typically from right-click or long-press).

--- a/Core/Source/MVVM/ViewModel.swift
+++ b/Core/Source/MVVM/ViewModel.swift
@@ -55,44 +55,49 @@ public struct SecondaryActionInfo {
             case off
             case mixed
         }
+
+        public init(
+            title: String,
+            state: Metadata.State = .off,
+            enabled: Bool = true,
+            imageName: String? = nil,
+            keyEquivalent: String = ""
+        ) {
+            self.title = title
+            self.state = state
+            self.enabled = enabled
+            self.imageName = imageName
+            self.keyEquivalent = keyEquivalent
+        }
+
+        // Enforce some common conventions (for example, state is off, no keyEquivalent).
+        public static func forNestedAction(
+            title: String,
+            enabled: Bool = true,
+            imageName: String? = nil
+        ) -> Metadata {
+            return Metadata(title: title, state: .off, enabled: enabled, imageName: imageName)
+        }
     }
 
-    public init(
-        action: Action,
-        title: String,
-        state: Metadata.State = .off,
-        enabled: Bool = true,
-        imageName: String? = nil,
-        keyEquivalent: String = ""
-    ) {
+    public init(metadata: Metadata, action: Action) {
+        self.metadata = metadata
         self.action = action
-        self.metadata = Metadata(
-            title: title,
-            state: state,
-            enabled: enabled,
-            imageName: imageName,
-            keyEquivalent: keyEquivalent)
     }
 
-    public let action: Action
     public let metadata: Metadata
+    public let action: Action
 }
 
 /// Describes a group of nested SecondaryActions.
 public struct NestedActionsInfo {
-
-    public init(title: String, enabled: Bool = true, imageName: String? = nil, actions: [SecondaryAction]) {
-        self.metadata = SecondaryActionInfo.Metadata(
-            title: title,
-            state: .off,
-            enabled: enabled,
-            imageName: imageName,
-            keyEquivalent: "")
+    public init(metadata: SecondaryActionInfo.Metadata, actions: [SecondaryAction]) {
+        self.metadata = metadata
         self.actions = actions
     }
 
-    public let actions: [SecondaryAction]
     public let metadata: SecondaryActionInfo.Metadata
+    public let actions: [SecondaryAction]
 }
 
 /// Represents a secondary action to be displayed in a list to the user (typically from right-click or long-press).

--- a/Core/Source/MVVM/ViewModel.swift
+++ b/Core/Source/MVVM/ViewModel.swift
@@ -64,7 +64,7 @@ public struct SecondaryActionInfo {
         enabled: Bool = true,
         imageName: String? = nil,
         keyEquivalent: String = ""
-        ) {
+    ) {
         self.action = action
         self.metadata = Metadata(
             title: title,

--- a/UI/Source/AppKitExtensions/NSMenu+Action.swift
+++ b/UI/Source/AppKitExtensions/NSMenu+Action.swift
@@ -10,7 +10,7 @@ extension NSMenu {
         _ actions: [SecondaryAction],
         action: Selector,
         target: AnyObject? = nil
-    ) -> NSMenu {
+        ) -> NSMenu {
         let menu = NSMenu()
 
         // Enabling is set explicitly per-item below.
@@ -19,11 +19,11 @@ extension NSMenu {
         actions.forEach { secondaryAction in
             switch secondaryAction {
             case .action(let info):
-                let menuItem = NSMenuItem(title: info.title, action: action, keyEquivalent: "")
-                menuItem.isEnabled = info.enabled
-                menuItem.state = info.state.toNSState()
+                let menuItem = NSMenuItem(title: info.metadata.title, action: action, keyEquivalent: "")
+                menuItem.isEnabled = info.metadata.enabled
+                menuItem.state = info.metadata.state.toNSState()
                 menuItem.representedObject = MenuItemActionWrapper(info.action)
-                if let imageName =  info.imageName {
+                if let imageName =  info.metadata.imageName {
                     menuItem.image = NSImage(named: imageName)
                 }
                 menuItem.target = target
@@ -40,9 +40,9 @@ extension NSMenu {
                 menu.addItem(NSMenuItem.separator())
 
             case .nested(let info):
-                let menuItem = NSMenuItem(title: info.title, action: nil, keyEquivalent: "")
-                menuItem.isEnabled = info.enabled
-                if let imageName =  info.imageName {
+                let menuItem = NSMenuItem(title: info.metadata.title, action: nil, keyEquivalent: "")
+                menuItem.isEnabled = info.metadata.enabled
+                if let imageName =  info.metadata.imageName {
                     menuItem.image = NSImage(named: imageName)
                 }
                 menu.addItem(menuItem)
@@ -66,7 +66,7 @@ extension NSMenuItem {
     }
 }
 
-extension SecondaryActionInfo.State {
+extension SecondaryActionInfo.Metadata.State {
     fileprivate func toNSState() -> Int {
         switch self {
         case .on:

--- a/UI/Source/AppKitExtensions/NSMenu+Action.swift
+++ b/UI/Source/AppKitExtensions/NSMenu+Action.swift
@@ -10,7 +10,7 @@ extension NSMenu {
         _ actions: [SecondaryAction],
         action: Selector,
         target: AnyObject? = nil
-        ) -> NSMenu {
+    ) -> NSMenu {
         let menu = NSMenu()
 
         // Enabling is set explicitly per-item below.


### PR DESCRIPTION
- Separate SecondaryActionInfo.Metadata from the action. This will be used for AppAction validation.
- Add keyEquivalent support to SecondaryAction.Metadata