### PR TITLE
Add characters associated value to properly handle keyboard layouts

### DIFF
--- a/Core/Source/MVVM/ViewModelUserEvents.swift
+++ b/Core/Source/MVVM/ViewModelUserEvents.swift
@@ -6,7 +6,11 @@ public enum ViewModelUserEvent {
     case click
 
     /// Represents the user typing a key with modifier flags.
-    case keyDown(EventKeyCode, EventKeyModifierFlags)
+    ///
+    /// Note: first associated value represents the device and layout independent keycode (see NSEvent.keyCode) whereas
+    /// the third optional String uses the NSEvent.characters event to return the correct value respecting keyboard
+    /// layout.
+    case keyDown(EventKeyCode, EventKeyModifierFlags, String?)
 
     /// Reprsents the user performing a long-press on the target view model.
     case longPress
@@ -56,8 +60,9 @@ extension ViewModelUserEvent: Hashable {
         switch self {
         case .click:
             return 1<<0
-        case .keyDown(let key, let flags):
-            return "keyDown-\(key)-\(flags)".hashValue
+        case .keyDown(let key, let flags, let characters):
+            let charValue = characters ?? "nil"
+            return "keyDown-\(key)-\(flags)-\(charValue)".hashValue
         case .longPress:
             return 1<<1
         case .secondaryClick:
@@ -76,15 +81,15 @@ extension ViewModelUserEvent: Hashable {
         case (.click, .click), (.longPress, .longPress), (.secondaryClick, .secondaryClick), (.select, .select),
              (.tap, .tap), (.copy, .copy):
             return true
-        case (.keyDown(let lKey, let lModifiers), .keyDown(let rKey, let rModifiers)):
-            return lKey == rKey && lModifiers == rModifiers
+        case (.keyDown(let lKey, let lModifiers, let lCharacters), .keyDown(let rKey, let rModifiers, let rCharacters)):
+            return lKey == rKey && lModifiers == rModifiers && lCharacters == rCharacters
         case (.click, _), (.longPress, _), (.secondaryClick, _), (.select, _), (.tap, _), (.keyDown, _), (.copy, _):
             return false
         }
     }
 
-    public static var spaceKey = ViewModelUserEvent.keyDown(.space, [])
-    public static var enterKey = ViewModelUserEvent.keyDown(.enter, [])
+    public static var spaceKey = ViewModelUserEvent.keyDown(.space, [], " ")
+    public static var enterKey = ViewModelUserEvent.keyDown(EventKeyCode.return, [], "\r")
 }
 
 // swiftlint:disable type_name

--- a/Examples/DirectoryViewer/DirectoryViewer/FileViewModel.swift
+++ b/Examples/DirectoryViewer/DirectoryViewer/FileViewModel.swift
@@ -15,6 +15,15 @@ public struct FileViewModel: ViewModel {
         return file.url
     }
 
+    public func actionForUserEvent(_ event: ViewModelUserEvent) -> Action? {
+        if case .keyDown(_, let modifiers, let characters) = event {
+            if modifiers.contains(.command) && characters == "o" {
+                return OpenFilesAction(urls: [url])
+            }
+        }
+        return nil
+    }
+
     public func handleDoubleClick() {
         OpenFilesAction(urls: [url]).send(from: context)
     }

--- a/UI/Source/CollectionViews/mac/CollectionView.swift
+++ b/UI/Source/CollectionViews/mac/CollectionView.swift
@@ -10,7 +10,8 @@ public protocol CollectionViewDelegate: NSCollectionViewDelegate {
     @objc optional func collectionViewDidReceiveKeyEvent(
         _ collectionView: NSCollectionView,
         key: EventKeyCode,
-        modifiers: AppKitEventModifierFlags
+        modifiers: AppKitEventModifierFlags,
+        characters: String?
     ) -> Bool
 
     /// Invoked when a specific index path is clicked upon - this allows the client to handle clicks without breaking
@@ -52,7 +53,8 @@ public final class CollectionView: NSCollectionView {
         let handled = internalDelegate?.collectionViewDidReceiveKeyEvent?(
             self,
             key: event.eventKeyCode,
-            modifiers: event.eventKeyModifierFlags.modifierFlags)
+            modifiers: event.eventKeyModifierFlags.modifierFlags,
+            characters: event.characters)
         guard handled != true else { return }
         switch event.eventKeyCode {
         case .upArrow, .downArrow:

--- a/UI/Source/CollectionViews/mac/CollectionViewController.swift
+++ b/UI/Source/CollectionViews/mac/CollectionViewController.swift
@@ -222,9 +222,10 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
     open func collectionViewDidReceiveKeyEvent(
         _ collectionView: NSCollectionView,
         key: EventKeyCode,
-        modifiers: AppKitEventModifierFlags
+        modifiers: AppKitEventModifierFlags,
+        characters: String?
     ) -> Bool {
-        let event = ViewModelUserEvent.keyDown(key, modifiers.eventKeyModifierFlags)
+        let event = ViewModelUserEvent.keyDown(key, modifiers.eventKeyModifierFlags, characters)
         return handleUserEvent(event)
     }
 


### PR DESCRIPTION
Previously ViewModelUserEvent.keyDown only included the device-independent keyCode which didn't take keyboard layout into account. I didn't remove keyCode since its still valuable for matching some keys (for example the arrow keys).