### PR TITLE
Fix ViewBinder’s handling of subclasses.

### DIFF
--- a/UI/Source/CollectionViews/mac/CollectionViewHostItem.swift
+++ b/UI/Source/CollectionViews/mac/CollectionViewHostItem.swift
@@ -11,8 +11,8 @@ public final class CollectionViewHostItem: NSCollectionViewItem {
     public var hostedView: View? {
         willSet {
             if let view = hostedView as? NSView {
-                if let newValue = newValue as? NSView , newValue.classForCoder == view.classForCoder {
-                    // NOOP: The view classes are the same, so no need to remove.
+                if let newValue = newValue as? NSView, newValue == view {
+                    // NOOP: The view is the same, so no need to remove.
                 } else {
                     // TODO:(wkiefer) This also needs to unbind here (see TODO in the data source)
                     view.removeFromSuperview()
@@ -21,7 +21,9 @@ public final class CollectionViewHostItem: NSCollectionViewItem {
         }
         didSet {
             // Only add the view if it isn't already added (i.e. hit the noop case in `willSet`.)
-            if let theView = hostedView as? NSView , theView.superview != view {
+            if let view = hostedView as? NSView, newValue == view {
+                // NOOP: The view is the same, so no need to add.
+            } else {
                 view.addSubview(theView)
                 theView.translatesAutoresizingMaskIntoConstraints = false
                 theView.constrain(edgesEqualToView: view)

--- a/UI/Source/CollectionViews/mac/CollectionViewHostItem.swift
+++ b/UI/Source/CollectionViews/mac/CollectionViewHostItem.swift
@@ -21,9 +21,7 @@ public final class CollectionViewHostItem: NSCollectionViewItem {
         }
         didSet {
             // Only add the view if it isn't already added (i.e. hit the noop case in `willSet`.)
-            if let view = hostedView as? NSView, newValue == view {
-                // NOOP: The view is the same, so no need to add.
-            } else {
+            if let theView = hostedView as? NSView , theView.superview != view {
                 view.addSubview(theView)
                 theView.translatesAutoresizingMaskIntoConstraints = false
                 theView.constrain(edgesEqualToView: view)


### PR DESCRIPTION
Given a ViewBinding that returns a subclass of A- either A1 or A2, the ViewBinding’s `viewType` is A. Currently, when checking whether to reuse a view that was generated by such a ViewBinding, the comparison check of `type(of: hostUIView) == viewType` returns false because A != A1, indicating a new view should be generated. But when the newly generated view is set to hostView, the types are compared again and match, resulting in the old view not being removed. This results in duplicate views every time the view is reused.

Instead, remove the first type check since generate() already attempts to cast reusable view to the correct type).
Additionally, add a precondition check to makes sure that CollectionViewHostItem only contains the current hostedView.

Previous failing example:
```
return ViewBinding {
    if UserDefaults.forDevice().isExperimentEnabled(.noteView) {
        return NoteView()
    } else {
        return TextView()
    }
}
```