### PR TITLE
Remove newlines from test failure messages

### DIFF
--- a/Core/Tests/MVVM/ModelCollectionHelpers.swift
+++ b/Core/Tests/MVVM/ModelCollectionHelpers.swift
@@ -30,7 +30,7 @@ internal func assertModelCollectionState(
                 }
             }
         } else {
-            XCTFail("Expected .loading(\(String(describing: expectedSections)))\ngot: \(actual)", file: file, line: line)
+            XCTFail("Expected .loading(\(String(describing: expectedSections))). Actual: \(actual)", file: file, line: line)
         }
     case .loaded(let expectedSections):
         if case .loaded(let actualSections) = actual {
@@ -42,7 +42,7 @@ internal func assertModelCollectionState(
                 XCTAssertEqual(e.map({ $0.modelId }), a.map({ $0.modelId }))
             }
         } else {
-            XCTFail("Expected .loaded with \(expectedSections))\ngot: \(actual)", file: file, line: line)
+            XCTFail("Expected .loaded with \(expectedSections)). Actual: \(actual)", file: file, line: line)
         }
     }
 }


### PR DESCRIPTION
Our CI doesn't display >1 line of test failure messages so the current format makes these messages a lot less useful.