### PR TITLE
Fix Async Helpers

### DIFF
--- a/Pilot.xcodeproj/xcshareddata/xcschemes/Pilot iOS.xcscheme
+++ b/Pilot.xcodeproj/xcshareddata/xcschemes/Pilot iOS.xcscheme
@@ -26,6 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
+      enableUBSanitizer = "YES"
       language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
@@ -56,11 +58,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      disableMainThreadChecker = "YES"
       language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      stopOnEveryThreadSanitizerIssue = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>

--- a/Pilot.xcodeproj/xcshareddata/xcschemes/Pilot macOS.xcscheme
+++ b/Pilot.xcodeproj/xcshareddata/xcschemes/Pilot macOS.xcscheme
@@ -26,6 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
+      enableUBSanitizer = "YES"
       language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
@@ -56,6 +58,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      disableMainThreadChecker = "YES"
       language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"


### PR DESCRIPTION
Fixes a bad race in our async helpers.

I initially was chasing a thread sanitizer error on some code that looked something like:

```
var result: T?
Async.onBackground {
    result = expensiveOperation()
}.onMain {
    self.view.result = result
}
```

I eventually realized we had an incorrect assumption about `DispatchWorkItem.notify(queue:work)`. The documentation for the [swift wrapper]() just says:

> This function schedules a notification block to be submitted to the specified queue when all blocks associated with the dispatch group have completed. If the group is empty (no block objects are associated with the dispatch group), the notification block object is submitted immediately. When the notification block is submitted, the group is empty.

Which looks great! Seems to be exactly what we need.... But if you look at the implementation of notify in [Block.swift](https://github.com/apple/swift/blob/adc54c8a4d13fbebfeb68244bac401ef2528d6d0/stdlib/public/SDK/Dispatch/Block.swift#L70) it clearly is just calling through to the GCD `dispatch_block_notify` function. That function has a much more [verbose documentation page](https://developer.apple.com/documentation/dispatch/1431042-dispatch_block_notify) including an important section:

> A single dispatch block may either be observed one or more times and executed once, or it may be executed any number of times. The behavior of any other combination is undefined. **Submission to a dispatch queue counts as an execution, even if cancellation using the dispatch_block_cancel function means the block's code never runs**.

So given that its there's definitely a possibility of a race where the block is submitted but the code hasn't actually run which explains why the thread sanitizer complains about the unprotected read/write to result. 

I was able to fix, while maintaining the same API by using a DispatchGroup which internally keeps an [atomic int as a semaphore](https://github.com/apple/swift-corelibs-libdispatch/blob/21273de3ba702c9a28967ef7d6c65e8e0320f43c/src/semaphore.c#L236) to track the number of enters/leaves, fixing this issue.