### PR TITLE
Add timestamp to CollectionViewDelegate collectionViewDidReceiveKeyEvent method.

### DIFF
--- a/UI/Source/CollectionViews/mac/CollectionView.swift
+++ b/UI/Source/CollectionViews/mac/CollectionView.swift
@@ -11,6 +11,7 @@ public protocol CollectionViewDelegate: NSCollectionViewDelegate {
         _ collectionView: NSCollectionView,
         key: EventKeyCode,
         modifiers: AppKitEventModifierFlags,
+        timestamp: TimeInterval,
         characters: String?
     ) -> Bool
 
@@ -54,6 +55,7 @@ public final class CollectionView: NSCollectionView {
             self,
             key: event.eventKeyCode,
             modifiers: event.eventKeyModifierFlags.modifierFlags,
+            timestamp: event.timestamp,
             characters: event.characters)
         guard handled != true else { return }
         switch event.eventKeyCode {

--- a/UI/Source/CollectionViews/mac/CollectionViewController.swift
+++ b/UI/Source/CollectionViews/mac/CollectionViewController.swift
@@ -223,6 +223,7 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
         _ collectionView: NSCollectionView,
         key: EventKeyCode,
         modifiers: AppKitEventModifierFlags,
+        timestamp: TimeInterval,
         characters: String?
     ) -> Bool {
         let event = ViewModelUserEvent.keyDown(key, modifiers.eventKeyModifierFlags, characters)


### PR DESCRIPTION
This allows a delegate to coalese key events if it needs to.