### PR TITLE
Actually use expectations correctly for FilteredModelCollectionTests

### DIFF
--- a/Core/Tests/MVVM/ModelCollectionHelpers.swift
+++ b/Core/Tests/MVVM/ModelCollectionHelpers.swift
@@ -11,38 +11,63 @@ internal func assertModelCollectionState(
     file: StaticString = #file,
     line: UInt = #line
 ) {
+    if let error = describeModelCollectionStateDiscrepancy(expected: expected, actual: actual) {
+        XCTFail(error, file: file, line: line)
+    }
+}
+
+/// Gives debugging description of why an actual model collection state is different from an expected state.
+/// Returns nil if the states are the same, only checks model IDs are consistent doesn't check individual models.
+internal func describeModelCollectionStateDiscrepancy(
+    expected: ModelCollectionState,
+    actual: ModelCollectionState
+) -> String? {
     switch expected {
     case .notLoaded:
-        if case .notLoaded = actual { return }
-        XCTFail("Expected .notLoaded state, got \(actual)", file: file, line: line)
+        if case .notLoaded = actual { return nil }
+        return "Expected .notLoaded state, got \(actual)"
     case .error:
-        if case .error = actual { return }
-        XCTFail("Expected .error state, got \(actual)", file: file, line: line)
+        if case .error = actual { return nil }
+        return "Expected .error state, got \(actual)"
     case .loading(let expectedSections):
         if case .loading(let actualSections) = actual {
-            XCTAssertEqual(
-                expectedSections?.count,
-                actualSections?.count,
-                "Expected .loading with \(expectedSections?.count ?? 0) sections, got \(actualSections?.count ?? 0)")
+            if expectedSections?.count != actualSections?.count {
+                let e = String(describing: expectedSections?.count)
+                let a = String(describing: actualSections?.count)
+                return "Expected .loading with \(e) sections got \(a)"
+            }
             if let expectedSections = expectedSections, let actualSections = actualSections {
                 for (e, a) in zip(expectedSections, actualSections) {
-                    XCTAssertEqual(e.map({ $0.modelId }), a.map({ $0.modelId }))
+                    if (e.map({ $0.modelId }) != a.map({ $0.modelId })) {
+                        return "\(e) != \(a)"
+                    }
                 }
             }
         } else {
-            XCTFail("Expected .loading(\(String(describing: expectedSections))). Actual: \(actual)", file: file, line: line)
+            return "Expected .loading(\(String(describing: expectedSections))). Actual: \(actual)"
         }
     case .loaded(let expectedSections):
         if case .loaded(let actualSections) = actual {
-            XCTAssertEqual(
-                expectedSections.count,
-                actualSections.count,
-                "Expected .loaded with \(expectedSections.count) sections got \(actualSections.count)")
+            if expectedSections.count != actualSections.count {
+                return "Expected .loaded with \(expectedSections.count) sections got \(actualSections.count)"
+            }
             for (e, a) in zip(expectedSections, actualSections) {
-                XCTAssertEqual(e.map({ $0.modelId }), a.map({ $0.modelId }))
+                if (e.map({ $0.modelId }) != a.map({ $0.modelId })) {
+                    return "\(e) != \(a)"
+                }
             }
         } else {
-            XCTFail("Expected .loaded with \(expectedSections)). Actual: \(actual)", file: file, line: line)
+            return "Expected .loaded with \(expectedSections)). Actual: \(actual)"
         }
     }
+    return nil
+}
+
+/// Gives debugging description of why an actual model collection state is different from an expected state.
+
+internal func validateModelCollectionState(
+    expected: ModelCollectionState,
+    actual: ModelCollectionState
+) -> Bool {
+    return describeModelCollectionStateDiscrepancy(expected: expected, actual: actual) == nil
 }

--- a/Core/Tests/MVVM/ModelCollectionHelpers.swift
+++ b/Core/Tests/MVVM/ModelCollectionHelpers.swift
@@ -16,8 +16,10 @@ internal func assertModelCollectionState(
     }
 }
 
-/// Gives debugging description of why an actual model collection state is different from an expected state.
-/// Returns nil if the states are the same, only checks model IDs are consistent doesn't check individual models.
+/// Gives debugging description of why an actual model collection state is different from an expected state. Returns nil
+/// if the states are the same.
+///
+/// Note: Only checks model IDs are consistent doesn't check individual models.
 internal func describeModelCollectionStateDiscrepancy(
     expected: ModelCollectionState,
     actual: ModelCollectionState
@@ -63,8 +65,7 @@ internal func describeModelCollectionStateDiscrepancy(
     return nil
 }
 
-/// Gives debugging description of why an actual model collection state is different from an expected state.
-
+/// Returns true if `actual` ModelCollectionState matches `expected`.
 internal func validateModelCollectionState(
     expected: ModelCollectionState,
     actual: ModelCollectionState


### PR DESCRIPTION
Previous test conditions here were pretty bad, effectively forcing a fixed delay before inspecting the during which async filtering hopefully happens and then inspecting model collection state directly. This caused some flakes in our CI. Now properly observe the MC and fulfill or fail the tests based on matching the condition expected.