### PR TITLE
Restrict fileprivate access levels down to private (unlocked by Swift 4 upgrade)

### DIFF
--- a/Core/Source/Logging/Logger.swift
+++ b/Core/Source/Logging/Logger.swift
@@ -128,7 +128,7 @@ public struct Log {
 
     // MARK: Private
 
-    static fileprivate func log(_ severity: Severity, category: Category, message: String) {
+    static private func log(_ severity: Severity, category: Category, message: String) {
         Async.on(loggingQueue) {
             let date = Date()
             for (_, logger) in loggers {
@@ -137,13 +137,13 @@ public struct Log {
         }
     }
 
-    static fileprivate let loggingQueue: Queue = .custom(DispatchQueue(
+    static private let loggingQueue: Queue = .custom(DispatchQueue(
         label: "com.dropbox.pilot.log.loggingQ",
         attributes: []
     ))
 
-    static fileprivate var nextLoggerToken: Int = 0
-    static fileprivate var loggers: [LoggerToken: Logger] = [:]
+    static private var nextLoggerToken: Int = 0
+    static private var loggers: [LoggerToken: Logger] = [:]
 }
 
 public func < (lhs: Log.Severity, rhs: Log.Severity) -> Bool {

--- a/Core/Source/MVVM/Model.swift
+++ b/Core/Source/MVVM/Model.swift
@@ -216,7 +216,7 @@ extension ModelVersionMixer: Encoder {
     }
 }
 
-fileprivate class ModelVersionEncoder {
+private class ModelVersionEncoder {
     public enum Marker: UInt8 {
         case None
 
@@ -248,7 +248,7 @@ fileprivate class ModelVersionEncoder {
         self.mixer = mixer
     }
 
-    fileprivate func mix(marker: Marker) {
+    private func mix(marker: Marker) {
         if closeContainerMarker != .None {
             mix(marker: closeContainerMarker)
             closeContainerMarker = .None
@@ -256,8 +256,8 @@ fileprivate class ModelVersionEncoder {
         mixer.mix(marker.rawValue)
     }
 
-    fileprivate var mixer: ModelVersionMixer
-    fileprivate var closeContainerMarker: Marker = .None
+    private var mixer: ModelVersionMixer
+    private var closeContainerMarker: Marker = .None
 }
 
 extension ModelVersionEncoder: Encoder {
@@ -385,7 +385,7 @@ extension ModelVersionEncoder: UnkeyedEncodingContainer {
     }
 }
 
-fileprivate struct ModelVersionKeyedEncoder<K: CodingKey>: KeyedEncodingContainerProtocol {
+private struct ModelVersionKeyedEncoder<K: CodingKey>: KeyedEncodingContainerProtocol {
     public typealias Key = K
 
     public init(_ encoder: ModelVersionEncoder) {

--- a/Core/Source/MVVM/ViewModelBinding.swift
+++ b/Core/Source/MVVM/ViewModelBinding.swift
@@ -64,7 +64,7 @@ public struct BlockViewModelBindingProvider: ViewModelBindingProvider {
 }
 
 /// Simple shim that forwards methods from `SelectionViewModel` to a single `ViewModel`.
-fileprivate struct ViewModelSelectionShim: SelectionViewModel {
+private struct ViewModelSelectionShim: SelectionViewModel {
     init(viewModels: [ViewModel], context: Context) {
         guard let vm = viewModels.first else { fatalError("Shim constructed with empty view model collection") }
         self.context = context

--- a/Core/Source/Token.swift
+++ b/Core/Source/Token.swift
@@ -35,12 +35,14 @@ public struct Token: Hashable, Equatable {
         self.value = value
     }
 
-    fileprivate let value: Int64
+    private let value: Int64
 
     // If we created tokens once per nanosecond (impossible), it would take almost 300 years to overflow
     private static var nextValue: Int64 = 0
-}
 
-public func == (lhs: Token, rhs: Token) -> Bool {
-    return lhs.value == rhs.value
+    // MARK: Equatable
+
+    public static func == (lhs: Token, rhs: Token) -> Bool {
+        return lhs.value == rhs.value
+    }
 }

--- a/Core/Tests/Logging/LoggingTests.swift
+++ b/Core/Tests/Logging/LoggingTests.swift
@@ -20,7 +20,7 @@ class LoggingTests: XCTestCase {
         super.tearDown()
     }
 
-    fileprivate var urlsToMoveToTrash: [URL] = []
+    private var urlsToMoveToTrash: [URL] = []
 
     func testLog() {
         let expectation = self.expectation(description: "logHub completion")
@@ -43,7 +43,7 @@ class LoggingTests: XCTestCase {
         Log.removeLogger(loggerToken)
     }
 
-    fileprivate func makeTestURLForFileLogger() throws -> URL {
+    private func makeTestURLForFileLogger() throws -> URL {
         let cachesDirectoryUrl = try FileManager.default.url(
             for: FileManager.SearchPathDirectory.cachesDirectory,
             in: FileManager.SearchPathDomainMask.userDomainMask,
@@ -65,5 +65,5 @@ struct TestLogger: Logger {
         XCTAssert(domain == "pilot.tests")
         expectation.fulfill()
     }
-    fileprivate let expectation: XCTestExpectation
+    private let expectation: XCTestExpectation
 }

--- a/Core/Tests/MVVM/FilteredModelCollectionTests.swift
+++ b/Core/Tests/MVVM/FilteredModelCollectionTests.swift
@@ -168,7 +168,7 @@ class FilteredModelCollectionTests: XCTestCase {
 
     // MARK: Test Helpers
 
-    fileprivate func createFilteredModelCollection(
+    private func createFilteredModelCollection(
         _ data: [[SModel]] = testData,
         kind: FilteredModelCollection.FilterKind = .sync,
         filter: ModelFilter? = nil
@@ -178,5 +178,5 @@ class FilteredModelCollectionTests: XCTestCase {
         return FilteredModelCollection(sourceCollection: source, kind: kind, filter: filter)
     }
 
-    fileprivate var filteredModelCollection: FilteredModelCollection!
+    private var filteredModelCollection: FilteredModelCollection!
 }

--- a/Core/Tests/MVVM/MappedModelCollectionTests.swift
+++ b/Core/Tests/MVVM/MappedModelCollectionTests.swift
@@ -66,7 +66,7 @@ class MappedModelCollectionTests: XCTestCase {
 
     // MARK: Helpers
 
-    fileprivate func createFilteredModelCollection(_ data: [[Model]] = testData) -> MappedModelCollection {
+    private func createFilteredModelCollection(_ data: [[Model]] = testData) -> MappedModelCollection {
         let source = StaticModelCollection(collectionId: "source", initialData: data)
         let modelCollection = MappedModelCollection(sourceCollection: source)
         modelCollection.transform = { model in return model }
@@ -89,5 +89,5 @@ class MappedModelCollectionTests: XCTestCase {
         return modelCollection
     }
 
-    fileprivate var modelCollection: MappedModelCollection!
+    private var modelCollection: MappedModelCollection!
 }

--- a/Core/Tests/Observable/ObservableTests.swift
+++ b/Core/Tests/Observable/ObservableTests.swift
@@ -15,8 +15,8 @@ class SemaphoreExpectation {
         expectations.popLast()!.fulfill()
     }
 
-    fileprivate let testCase: XCTestCase
-    fileprivate var expectations: [XCTestExpectation] = []
+    private let testCase: XCTestCase
+    private var expectations: [XCTestExpectation] = []
 }
 
 class ObservableTests: XCTestCase {

--- a/UI/Source/AppKitExtensions/NSCollectionView+Selection.swift
+++ b/UI/Source/AppKitExtensions/NSCollectionView+Selection.swift
@@ -120,7 +120,7 @@ public extension NSCollectionView {
         }
     }
 
-    fileprivate var hostScrollView: NSScrollView? {
+    private var hostScrollView: NSScrollView? {
         var next = superview
         while next != nil && next as? NSScrollView == nil {
             next = next?.superview
@@ -128,7 +128,7 @@ public extension NSCollectionView {
         return next as? NSScrollView
     }
 
-    fileprivate func setSingleSelection(_ item: Int, section: Int) {
+    private func setSingleSelection(_ item: Int, section: Int) {
         let selectedIndexPath = IndexPath(forModelItem: item, inSection: section)
         selectionIndexPaths = [selectedIndexPath]
         verticallyScrollTo(itemAtIndexPath: selectedIndexPath)

--- a/UI/Source/AppKitExtensions/NSMenu+Action.swift
+++ b/UI/Source/AppKitExtensions/NSMenu+Action.swift
@@ -98,7 +98,7 @@ public extension SecondaryActionInfo.Metadata.State {
 }
 
 /// Helper class to wrap value-type `Action`s.
-fileprivate final class MenuItemActionWrapper: NSObject {
+private final class MenuItemActionWrapper: NSObject {
 
     fileprivate convenience init(_ action: Action) {
         self.init()

--- a/UI/Source/CollectionViews/CollectionViewModelDataSource.swift
+++ b/UI/Source/CollectionViews/CollectionViewModelDataSource.swift
@@ -45,7 +45,7 @@ public final class CurrentCollection: ModelCollection, ProxyingCollectionEventOb
 
     public let collectionId: ModelCollectionId
 
-    public fileprivate(set) var state: ModelCollectionState = .notLoaded {
+    public private(set) var state: ModelCollectionState = .notLoaded {
         didSet {
             observers.notify(.didChangeState(state))
         }
@@ -330,36 +330,36 @@ public class CollectionViewModelDataSource: NSObject, ProxyingObservable {
     // MARK: Observable
 
     public var proxiedObservable: GenericObservable<Event> { return observers }
-    fileprivate let observers = ObserverList<Event>()
+    private let observers = ObserverList<Event>()
 
     // MARK: Private
 
-    fileprivate let modelBinder: ViewModelBindingProvider
-    fileprivate let viewBinder: ViewBindingProvider
+    private let modelBinder: ViewModelBindingProvider
+    private let viewBinder: ViewBindingProvider
 
     /// The collection whose contents are synchronized to this CollectionView.
     /// The underlyingCollection's data may be newer than the CollectionView's understanding of the world.
-    fileprivate let underlyingCollection: SwitchableModelCollection
-    fileprivate var collectionViewState: CollectionViewState
+    private let underlyingCollection: SwitchableModelCollection
+    private var collectionViewState: CollectionViewState
 
-    fileprivate var collectionObserver: Observer?
+    private var collectionObserver: Observer?
 
     /// Cache of view models and sizing information.
-    fileprivate var viewModelCache: [ModelId: CachedViewModel] = [:]
+    private var viewModelCache: [ModelId: CachedViewModel] = [:]
 
     /// Map from supplementary element kind (as `String`) to binding providers for supplementary views.
-    fileprivate var supplementaryViewBinderMap: [String: ViewBindingProvider] = [:]
+    private var supplementaryViewBinderMap: [String: ViewBindingProvider] = [:]
 
     /// Map from supplementary element kind (as `String`) to binding providers for supplementary view models.
-    fileprivate var supplementaryViewModelBinderMap: [String: ViewModelBindingProvider] = [:]
+    private var supplementaryViewModelBinderMap: [String: ViewModelBindingProvider] = [:]
 
     /// Map from supplementary element kind (as `String`) to model provider for supplementary elements.
-    fileprivate var supplementaryModelProviderMap: [String: IndexedModelProvider] = [:]
+    private var supplementaryModelProviderMap: [String: IndexedModelProvider] = [:]
 
-    fileprivate var notificationTokens: [NSObjectProtocol] = []
-    fileprivate var inBackground = false
+    private var notificationTokens: [NSObjectProtocol] = []
+    private var inBackground = false
 
-    fileprivate func registerForNotifications() {
+    private func registerForNotifications() {
 #if os(iOS)
         let nc = NotificationCenter.default
 
@@ -381,13 +381,13 @@ public class CollectionViewModelDataSource: NSObject, ProxyingObservable {
 #endif // os(iOS)
     }
 
-    fileprivate func unregisterForNotifications() {
+    private func unregisterForNotifications() {
         let nc = NotificationCenter.default
         notificationTokens.forEach { nc.removeObserver($0) }
         notificationTokens.removeAll()
     }
 
-    fileprivate func modelForSupplementaryIndexPath(_ indexPath: IndexPath, ofKind kind: String) -> Model {
+    private func modelForSupplementaryIndexPath(_ indexPath: IndexPath, ofKind kind: String) -> Model {
         if let provider = supplementaryModelProviderMap[kind] {
             // If a provider was set, and that provider provides a model, use it.
             if let model = provider.model(for: indexPath, context: context) {
@@ -405,7 +405,7 @@ public class CollectionViewModelDataSource: NSObject, ProxyingObservable {
         return CollectionZeroItemModel(indexPath: indexPath)
     }
 
-    fileprivate func viewModelForSupplementaryElementAtIndexPath(_ kind: String, indexPath: IndexPath) -> ViewModel {
+    private func viewModelForSupplementaryElementAtIndexPath(_ kind: String, indexPath: IndexPath) -> ViewModel {
         let model = modelForSupplementaryIndexPath(indexPath, ofKind: kind)
         if let bindingProvider = supplementaryViewModelBinderMap[kind] {
             // Supplementary items don't necessarily have an item associated with them (think section headers for empty
@@ -422,7 +422,7 @@ public class CollectionViewModelDataSource: NSObject, ProxyingObservable {
         }
     }
 
-    fileprivate func cachedViewModel(for model: Model) -> CachedViewModel {
+    private func cachedViewModel(for model: Model) -> CachedViewModel {
         // Supplementary items don't necessarily have an item associated with them (think section headers for empty
         // sections) - so handle the "zero" case here.
         if let zeroModel = model as? CollectionZeroItemModel {
@@ -461,7 +461,7 @@ public class CollectionViewModelDataSource: NSObject, ProxyingObservable {
         }
     }
 
-    fileprivate func applyCurrentDataToCollectionView() {
+    private func applyCurrentDataToCollectionView() {
         precondition(collectionViewState == .synced)
 
         let (updates, commitCollectionChanges) = currentCollection.beginUpdate(underlyingCollection)
@@ -484,7 +484,7 @@ public class CollectionViewModelDataSource: NSObject, ProxyingObservable {
     }
 
 
-    fileprivate var collectionViewSectionCount: Int {
+    private var collectionViewSectionCount: Int {
         return collectionView?.numberOfSections ?? 0
     }
 
@@ -492,7 +492,7 @@ public class CollectionViewModelDataSource: NSObject, ProxyingObservable {
     /// This method should only be called once the `CollectionEventUpdates` have been committed to `currentCollection`,
     /// typically in `handleUpdateItems(...)` as it assumes the updates are already reflected in the current collection.
     /// Returns the invalidated view models.
-    fileprivate func invalidateViewModelCache(for updates: CollectionEventUpdates) -> [ModelId: CachedViewModel] {
+    private func invalidateViewModelCache(for updates: CollectionEventUpdates) -> [ModelId: CachedViewModel] {
         // Removals.
         for invalidatedModelId in updates.removedModelIds {
             viewModelCache[invalidatedModelId] = nil
@@ -529,7 +529,7 @@ extension CollectionViewModelDataSource: UICollectionViewDataSource {
 
     // MARK: Private
 
-    fileprivate func updatesShouldFallbackOnFullReload(_ updates: CollectionEventUpdates) -> Bool {
+    private func updatesShouldFallbackOnFullReload(_ updates: CollectionEventUpdates) -> Bool {
         // If `NoneReloadOnly` is specified, always reload.
         if case .noneReloadOnly = updateAnimationStyle {
             return true
@@ -678,7 +678,7 @@ extension CollectionViewModelDataSource: UICollectionViewDataSource {
         }
     }
 
-    fileprivate func rebindViewAtIndexPath(_ indexPath: IndexPath, toViewModel viewModel: ViewModel) {
+    private func rebindViewAtIndexPath(_ indexPath: IndexPath, toViewModel viewModel: ViewModel) {
         guard let collectionView = collectionView else { return }
         guard let cell = collectionView.cellForItem(at: indexPath) as? CollectionViewHostCell else { return }
 

--- a/UI/Source/CollectionViews/ios/CollectionViewController.swift
+++ b/UI/Source/CollectionViews/ios/CollectionViewController.swift
@@ -217,9 +217,9 @@ open class CollectionViewController: UIViewController, UICollectionViewDelegate 
 
     // MARK: Private
 
-    fileprivate var collectionObserver: Observer?
+    private var collectionObserver: Observer?
 
-    fileprivate func registerForModelEvents() {
+    private func registerForModelEvents() {
         assertWithLog(collectionObserver == nil, message: "Expected to start with a nil token")
 
         collectionObserver = collection.observe { [weak self] event in
@@ -230,11 +230,11 @@ open class CollectionViewController: UIViewController, UICollectionViewDelegate 
         handleModelEvent(.didChangeState(collection.state))
     }
 
-    fileprivate func unregisterForModelEvents() {
+    private func unregisterForModelEvents() {
         collectionObserver = nil
     }
 
-    fileprivate func handleModelEvent(_ event: CollectionEvent) {
+    private func handleModelEvent(_ event: CollectionEvent) {
         hideEmptyContentView()
 
         switch event {
@@ -259,12 +259,12 @@ open class CollectionViewController: UIViewController, UICollectionViewDelegate 
     }
 
     /// Spinner to show when in the `Loading` state.
-    fileprivate var spinner: UIActivityIndicatorView?
+    private var spinner: UIActivityIndicatorView?
 
     /// View which is displayed when there is no content (either due to error or lack of loaded data).
-    fileprivate var emptyContentView: UIView?
+    private var emptyContentView: UIView?
 
-    fileprivate func showEmptyContentView() {
+    private func showEmptyContentView() {
         guard self.emptyContentView == nil else { return }
 
         let display: EmptyCollectionDisplay
@@ -284,12 +284,12 @@ open class CollectionViewController: UIViewController, UICollectionViewDelegate 
         }
     }
 
-    fileprivate func hideEmptyContentView() {
+    private func hideEmptyContentView() {
         emptyContentView?.removeFromSuperview()
         emptyContentView = nil
     }
 
-    fileprivate func updateEmptyContentViewVisibility() {
+    private func updateEmptyContentViewVisibility() {
         switch collection.state {
         case .error(_), .loaded:
             if collection.isEmpty {
@@ -302,7 +302,7 @@ open class CollectionViewController: UIViewController, UICollectionViewDelegate 
         }
     }
 
-    fileprivate func emptyContentViewForDisplay(_ display: EmptyCollectionDisplay) -> UIView? {
+    private func emptyContentViewForDisplay(_ display: EmptyCollectionDisplay) -> UIView? {
         switch display {
         case .none:
             return nil

--- a/UI/Source/CollectionViews/ios/Nested/NestedModelCollectionView.swift
+++ b/UI/Source/CollectionViews/ios/Nested/NestedModelCollectionView.swift
@@ -78,6 +78,6 @@ public final class NestedModelCollectionView: UICollectionView, View {
 
     // MARK: Private
 
-    fileprivate var collectionViewModel: NestedModelCollectionViewViewModel?
-    fileprivate var alreadyCalledLayout = false
+    private var collectionViewModel: NestedModelCollectionViewViewModel?
+    private var alreadyCalledLayout = false
 }

--- a/UI/Source/CollectionViews/mac/CollectionView.swift
+++ b/UI/Source/CollectionViews/mac/CollectionView.swift
@@ -138,12 +138,12 @@ public final class CollectionView: NSCollectionView {
 
     // MARK: Private
 
-    fileprivate var internalDelegate: CollectionViewDelegate? {
+    private var internalDelegate: CollectionViewDelegate? {
         return delegate as? CollectionViewDelegate
     }
 
     @objc
-    fileprivate func autoSelectFirstItem() {
+    private func autoSelectFirstItem() {
         if autoSelectItemOnFocus && selectionIndexes.count == 0 {
             selectFirstItem()
         }

--- a/UI/Source/CollectionViews/mac/CollectionViewController.swift
+++ b/UI/Source/CollectionViews/mac/CollectionViewController.swift
@@ -590,7 +590,7 @@ private final class FullWidthScroller: NSScroller {
 }
 
 /// Private helper class to force the vertical scroller to always appear as a modern over-content scroller.
-fileprivate final class FullWidthScrollView: NSScrollView {
+private final class FullWidthScrollView: NSScrollView {
 
     fileprivate var scrollEnabled: Bool = true
 

--- a/UI/Source/CollectionViews/mac/CollectionViewHostItem.swift
+++ b/UI/Source/CollectionViews/mac/CollectionViewHostItem.swift
@@ -91,7 +91,7 @@ public final class CollectionViewHostItem: NSCollectionViewItem {
 
     // MARK: Private
 
-    fileprivate var cachedLayoutAttributes: NSCollectionViewLayoutAttributes?
+    private var cachedLayoutAttributes: NSCollectionViewLayoutAttributes?
 }
 
 extension NSCollectionViewItem.HighlightState {

--- a/UI/Tests/CollectionView/mac/CollectionViewTests.swift
+++ b/UI/Tests/CollectionView/mac/CollectionViewTests.swift
@@ -133,50 +133,50 @@ class CollectionViewTests: XCTestCase {
     }
 }
 
-fileprivate func makeDefaultLayout() -> NSCollectionViewLayout {
+private func makeDefaultLayout() -> NSCollectionViewLayout {
     let layout = NSCollectionViewFlowLayout()
     layout.itemSize = NSSize(width: 20, height: 20)
     return layout
 }
 
-fileprivate struct TestViewModel: ViewModel {
-    fileprivate init(model: Model, context: Context) {
+private struct TestViewModel: ViewModel {
+    private init(model: Model, context: Context) {
         self.model = model
         self.context = context
     }
 
-    fileprivate let model: Model
-    fileprivate var context: Context
+    private let model: Model
+    private var context: Context
 }
 
-fileprivate final class TestView: NSView, View {
-    fileprivate var viewModel: ViewModel?
+private final class TestView: NSView, View {
+    private var viewModel: ViewModel?
 
-    fileprivate func bindToViewModel(_ viewModel: ViewModel) {
+    private func bindToViewModel(_ viewModel: ViewModel) {
         self.viewModel = viewModel
     }
 
-    fileprivate func unbindFromViewModel() {
+    private func unbindFromViewModel() {
         self.viewModel = nil
     }
 }
 
-fileprivate final class AltTestView: NSView, View {
-    fileprivate var viewModel: ViewModel?
+private final class AltTestView: NSView, View {
+    private var viewModel: ViewModel?
 
-    fileprivate func bindToViewModel(_ viewModel: ViewModel) {
+    private func bindToViewModel(_ viewModel: ViewModel) {
         self.viewModel = viewModel
     }
 
-    fileprivate func unbindFromViewModel() {
+    private func unbindFromViewModel() {
         self.viewModel = nil
     }
 }
 
-fileprivate final class TestSupplementaryLayout: NSCollectionViewLayout {
-    fileprivate static let SupplementaryLayoutKind = NSCollectionView.SupplementaryElementKind.sectionHeader
+private final class TestSupplementaryLayout: NSCollectionViewLayout {
+    private static let SupplementaryLayoutKind = NSCollectionView.SupplementaryElementKind.sectionHeader
 
-    fileprivate override func layoutAttributesForElements(in rect: NSRect) -> [NSCollectionViewLayoutAttributes] {
+    private override func layoutAttributesForElements(in rect: NSRect) -> [NSCollectionViewLayoutAttributes] {
         var layoutAttrs = [NSCollectionViewLayoutAttributes]()
 
         if let attrs = layoutAttributesForItem(at: IndexPath(item: 0, section: 0)) {
@@ -190,13 +190,13 @@ fileprivate final class TestSupplementaryLayout: NSCollectionViewLayout {
         return layoutAttrs
     }
 
-    fileprivate override func layoutAttributesForItem(at indexPath: IndexPath) -> NSCollectionViewLayoutAttributes? {
+    private override func layoutAttributesForItem(at indexPath: IndexPath) -> NSCollectionViewLayoutAttributes? {
         let attrs = NSCollectionViewLayoutAttributes(forItemWith: indexPath)
         attrs.frame = NSRect(x: 0, y: 0, width: 20, height: 20)
         return attrs
     }
 
-    fileprivate override func layoutAttributesForSupplementaryView(
+    private override func layoutAttributesForSupplementaryView(
         ofKind elementKind: NSCollectionView.SupplementaryElementKind,
         at indexPath: IndexPath
     ) -> NSCollectionViewLayoutAttributes? {

--- a/UI/Tests/CollectionView/mac/CollectionViewTests.swift
+++ b/UI/Tests/CollectionView/mac/CollectionViewTests.swift
@@ -139,44 +139,44 @@ private func makeDefaultLayout() -> NSCollectionViewLayout {
     return layout
 }
 
-private struct TestViewModel: ViewModel {
-    private init(model: Model, context: Context) {
+fileprivate struct TestViewModel: ViewModel {
+    fileprivate init(model: Model, context: Context) {
         self.model = model
         self.context = context
     }
 
-    private let model: Model
-    private var context: Context
+    fileprivate let model: Model
+    fileprivate var context: Context
 }
 
-private final class TestView: NSView, View {
-    private var viewModel: ViewModel?
+fileprivate final class TestView: NSView, View {
+    fileprivate var viewModel: ViewModel?
 
-    private func bindToViewModel(_ viewModel: ViewModel) {
+    fileprivate func bindToViewModel(_ viewModel: ViewModel) {
         self.viewModel = viewModel
     }
 
-    private func unbindFromViewModel() {
+    fileprivate func unbindFromViewModel() {
         self.viewModel = nil
     }
 }
 
-private final class AltTestView: NSView, View {
-    private var viewModel: ViewModel?
+fileprivate final class AltTestView: NSView, View {
+    fileprivate var viewModel: ViewModel?
 
-    private func bindToViewModel(_ viewModel: ViewModel) {
+    fileprivate func bindToViewModel(_ viewModel: ViewModel) {
         self.viewModel = viewModel
     }
 
-    private func unbindFromViewModel() {
+    fileprivate func unbindFromViewModel() {
         self.viewModel = nil
     }
 }
 
-private final class TestSupplementaryLayout: NSCollectionViewLayout {
-    private static let SupplementaryLayoutKind = NSCollectionView.SupplementaryElementKind.sectionHeader
+fileprivate final class TestSupplementaryLayout: NSCollectionViewLayout {
+    fileprivate static let SupplementaryLayoutKind = NSCollectionView.SupplementaryElementKind.sectionHeader
 
-    private override func layoutAttributesForElements(in rect: NSRect) -> [NSCollectionViewLayoutAttributes] {
+    fileprivate override func layoutAttributesForElements(in rect: NSRect) -> [NSCollectionViewLayoutAttributes] {
         var layoutAttrs = [NSCollectionViewLayoutAttributes]()
 
         if let attrs = layoutAttributesForItem(at: IndexPath(item: 0, section: 0)) {
@@ -190,13 +190,13 @@ private final class TestSupplementaryLayout: NSCollectionViewLayout {
         return layoutAttrs
     }
 
-    private override func layoutAttributesForItem(at indexPath: IndexPath) -> NSCollectionViewLayoutAttributes? {
+    fileprivate override func layoutAttributesForItem(at indexPath: IndexPath) -> NSCollectionViewLayoutAttributes? {
         let attrs = NSCollectionViewLayoutAttributes(forItemWith: indexPath)
         attrs.frame = NSRect(x: 0, y: 0, width: 20, height: 20)
         return attrs
     }
 
-    private override func layoutAttributesForSupplementaryView(
+    fileprivate override func layoutAttributesForSupplementaryView(
         ofKind elementKind: NSCollectionView.SupplementaryElementKind,
         at indexPath: IndexPath
     ) -> NSCollectionViewLayoutAttributes? {


### PR DESCRIPTION
As of Swift 4, extensions in the same file as the original declaration can access private members of that declaration.