### PR TITLE
Represent layout priority as float to fix issue compiling apps in swift3

### DIFF
--- a/UI/Source/Layout/LayoutConstraints.swift
+++ b/UI/Source/Layout/LayoutConstraints.swift
@@ -59,7 +59,7 @@ extension NSLayoutConstraint {
         #if os(OSX)
         priority = NSLayoutConstraint.Priority(p)
         #else
-        priority = p
+        priority = UILayoutPriority(rawValue: p)
         #endif
         return self
     }

--- a/UI/Source/PlatformAliases.swift
+++ b/UI/Source/PlatformAliases.swift
@@ -9,7 +9,6 @@ public typealias PlatformCollectionViewLayoutInvalidationContext = UICollectionV
 public typealias PlatformCollectionViewUpdateItem = UICollectionViewUpdateItem
 public typealias PlatformEdgeInsets = UIEdgeInsets
 public typealias PlatformFont = UIFont
-public typealias PlatformLayoutPriority = UILayoutPriority
 public typealias PlatformScrollView = UIScrollView
 public typealias PlatformViewController = UIViewController
 public typealias PlatformView = UIView
@@ -25,8 +24,10 @@ public typealias PlatformCollectionViewLayoutInvalidationContext = NSCollectionV
 public typealias PlatformCollectionViewUpdateItem = NSCollectionViewUpdateItem
 public typealias PlatformEdgeInsets = NSEdgeInsets
 public typealias PlatformFont = NSFont
-public typealias PlatformLayoutPriority = Float
 public typealias PlatformScrollView = NSScrollView
 public typealias PlatformViewController = NSViewController
 public typealias PlatformView = NSView
 #endif
+
+// Temporary workaround to support swift 3 linking against pilot.
+public typealias PlatformLayoutPriority = Float


### PR DESCRIPTION
Just taking appkit fix and applying to iOS as well.