### PR TITLE
Support sections in SwitchableModelCollection

### DIFF
--- a/Core/Source/MVVM/SwitchableModelCollection.swift
+++ b/Core/Source/MVVM/SwitchableModelCollection.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A ModelCollection whose backing collection can be swapped out at runtime.
-public final class SwitchableModelCollection: ModelCollection, ProxyingCollectionEventObservable {
+public final class SwitchableModelCollection: SectionedModelCollection, ProxyingCollectionEventObservable {
 
     // MARK: Init
 
@@ -43,6 +43,14 @@ public final class SwitchableModelCollection: ModelCollection, ProxyingCollectio
 
     public var state: ModelCollectionState {
         return self.currentCollection.state
+    }
+
+    public var sectionedState: [ModelCollectionState] {
+        if let sectioned = currentCollection as? SectionedModelCollection {
+            return sectioned.sectionedState
+        } else {
+            return [currentCollection.state]
+        }
     }
 
     // MARK: CollectionEventObservable

--- a/Core/Tests/MVVM/ModelCollectionHelpers.swift
+++ b/Core/Tests/MVVM/ModelCollectionHelpers.swift
@@ -16,6 +16,26 @@ internal func assertModelCollectionState(
     }
 }
 
+/// Fails test case if `actual` model collection states aren't equivelant to `expected`.
+///
+/// Checks counts match then loops assertModelCollectionState, so inherits same caveats.
+internal func assertSectionedModelCollectionState(
+    expected: [ModelCollectionState],
+    actual: [ModelCollectionState],
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    guard expected.count == actual.count else {
+        XCTFail("Expected \(expected.count) sections got \(actual.count)")
+        return
+    }
+    for (idx, (expected, actual)) in zip(expected, actual).enumerated() {
+        if let error = describeModelCollectionStateDiscrepancy(expected: expected, actual: actual) {
+            XCTFail("Section \(idx): \(error)", file: file, line: line)
+        }
+    }
+}
+
 /// Gives debugging description of why an actual model collection state is different from an expected state. Returns nil
 /// if the states are the same.
 ///

--- a/Core/Tests/MVVM/SwitchableModelCollectionTests.swift
+++ b/Core/Tests/MVVM/SwitchableModelCollectionTests.swift
@@ -40,4 +40,18 @@ class SwitchableModelCollectionTests: XCTestCase {
         old.onNext(.loading(nil))
         assertModelCollectionState(expected: new.state, actual: subject.state)
     }
+
+    func testSwitchableSectioned() {
+        let old = SimpleModelCollection()
+        old.onNext(.loaded([]))
+        let subject = SwitchableModelCollection(modelCollection: old)
+        assertSectionedModelCollectionState(expected: subject.asSectioned().sectionedState, actual: [.loaded([])])
+        let newLoading = SimpleModelCollection()
+        newLoading.onNext(.loading(nil))
+        let new = ComposedModelCollection.multiplexing([old, newLoading])
+        subject.switchTo(new)
+        assertSectionedModelCollectionState(
+            expected: subject.asSectioned().sectionedState,
+            actual: [.loaded([]), .loading(nil)])
+    }
 }


### PR DESCRIPTION
Fixes issue where SwitchableModelCollection flattens the sectionedState in its currentCollection
if the currentCollection is sectioned.