### PR TITLE
Fix for iOS reuse logic

### DIFF
--- a/UI/Source/CollectionViews/ios/CollectionViewHostCell.swift
+++ b/UI/Source/CollectionViews/ios/CollectionViewHostCell.swift
@@ -10,7 +10,7 @@ internal final class CollectionViewHostCell: UICollectionViewCell {
     internal var hostedView: View? {
         willSet {
             if let view = hostedView as? UIView {
-                if let newValue = newValue as? UIView , newValue.classForCoder == view.classForCoder {
+                if let newValue = newValue as? UIView, newValue == view {
                     // NOOP: The view classes are the same, so no need to remove.
                 } else {
                     // TODO:(wkiefer) This also needs to unbind here (see TODO in the data source)

--- a/UI/Source/CollectionViews/ios/CollectionViewHostCell.swift
+++ b/UI/Source/CollectionViews/ios/CollectionViewHostCell.swift
@@ -11,7 +11,7 @@ internal final class CollectionViewHostCell: UICollectionViewCell {
         willSet {
             if let view = hostedView as? UIView {
                 if let newValue = newValue as? UIView, newValue == view {
-                    // NOOP: The view classes are the same, so no need to remove.
+                    // NOOP: The view is the same no need to remove.
                 } else {
                     // TODO:(wkiefer) This also needs to unbind here (see TODO in the data source)
                     view.removeFromSuperview()
@@ -27,7 +27,7 @@ internal final class CollectionViewHostCell: UICollectionViewCell {
         }
         didSet {
             // Only add the view if it isn't already added (i.e. hit the noop case in `willSet`.
-            if let view = hostedView as? UIView , view.superview != contentView {
+            if let view = hostedView as? UIView, view.superview != contentView {
                 view.autoresizingMask = [ .flexibleWidth, .flexibleHeight ]
                 view.frame = contentView.bounds
                 contentView.addSubview(view)


### PR DESCRIPTION
Noticed this while reviewing https://github.com/dropbox/pilot/pull/116 that the fix in 4e0d5b89ac31616d1e7b0b298f53e1cf61c6a109 was only applied to mac but it actually applies to both.

Short version...

> If the new value is anything other than the exact same instance as oldValue it is an error to not add that view as a subview and remove the oldValue. If we don't (as it is now when they're the same class) we end up in a case where the oldValue is not removed but we no longer have any reference to it and the hostedView property points to a NSView thats not in the view hierarchy so future rebinds etc will be pointless.

Longer discussion on #95 