### PR TITLE
[macOS] Allow a nested CollectionView to pass on scroll events to it's enclosing NSScrollView

### DIFF
--- a/UI/Source/CollectionViews/mac/CollectionViewController.swift
+++ b/UI/Source/CollectionViews/mac/CollectionViewController.swift
@@ -599,7 +599,28 @@ private final class FullWidthScrollView: NSScrollView {
     // MARK: NSScrollView
 
     fileprivate override func scrollWheel(with theEvent: NSEvent) {
-        if scrollEnabled {
+        guard scrollEnabled else {
+            enclosingScrollView?.scrollWheel(with: theEvent)
+            return
+        }
+
+        var selfShouldScroll = true
+        if let enclosingScrollView = enclosingScrollView, let documentView = documentView {
+            let documentVisibleRect = contentView.documentVisibleRect
+            let scrolledPastTop = documentVisibleRect.minY < documentView.frame.minY - contentInsets.top
+            let scrolledPastBottom = documentVisibleRect.maxY > documentView.frame.maxY + contentInsets.bottom
+
+            if scrolledPastBottom && theEvent.scrollingDeltaY < 0.0 {
+                enclosingScrollView.scrollWheel(with: theEvent)
+                selfShouldScroll = false
+            }
+            if scrolledPastTop && theEvent.scrollingDeltaY > 0.0 {
+                enclosingScrollView.scrollWheel(with: theEvent)
+                selfShouldScroll = false
+            }
+        }
+
+        if selfShouldScroll {
             super.scrollWheel(with: theEvent)
         }
     }


### PR DESCRIPTION
- If a CollectionView is nested inside another NSScrollView, when the collection view scrolls to/past top or bottom bounds, it'll forward the scrollWheel event to the enclosing NSScrollView.
- If the CollectionView has scrollingDisabled, it'll always pass the scrollWheel events up to the enclosing NSScrollView. 