### PR TITLE
Extract ModelCollectionViewController base class

### DIFF
--- a/Examples/DirectoryViewer/DirectoryViewer.xcodeproj/project.pbxproj
+++ b/Examples/DirectoryViewer/DirectoryViewer.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A4002D5D208FA87900B95A90 /* Pilot.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = A4143C9E1F7AD3CA00E91697 /* Pilot.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A4002D5E208FA87900B95A90 /* PilotUI.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = A4143CAA1F7AD3CA00E91697 /* PilotUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A4143C851F7AD3A000E91697 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4143C841F7AD3A000E91697 /* AppDelegate.swift */; };
 		A4143C871F7AD3A000E91697 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A4143C861F7AD3A000E91697 /* Assets.xcassets */; };
 		A4143C8A1F7AD3A000E91697 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = A4143C881F7AD3A000E91697 /* MainMenu.xib */; };
@@ -92,6 +94,20 @@
 			remoteInfo = "PilotUI macOS";
 		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		A4002D54208FA87000B95A90 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				A4002D5D208FA87900B95A90 /* Pilot.framework in CopyFiles */,
+				A4002D5E208FA87900B95A90 /* PilotUI.framework in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		A4143C811F7AD3A000E91697 /* DirectoryViewer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DirectoryViewer.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -190,6 +206,7 @@
 				A4143C7D1F7AD3A000E91697 /* Sources */,
 				A4143C7E1F7AD3A000E91697 /* Frameworks */,
 				A4143C7F1F7AD3A000E91697 /* Resources */,
+				A4002D54208FA87000B95A90 /* CopyFiles */,
 			);
 			buildRules = (
 			);

--- a/Examples/DirectoryViewer/DirectoryViewer/DirectoryViewController.swift
+++ b/Examples/DirectoryViewer/DirectoryViewer/DirectoryViewController.swift
@@ -26,6 +26,10 @@ public final class DirectoryViewController: CollectionViewController {
         collectionView.allowsMultipleSelection = true
     }
 
+    public override func displayForNoContentState() -> EmptyCollectionDisplay {
+        return .text("Nothing to see here…", NSFont.boldSystemFont(ofSize: 14), NSColor.disabledControlTextColor)
+    }
+
     // MARK: Private
 
     private let flowLayout: NSCollectionViewFlowLayout

--- a/Pilot.xcodeproj/project.pbxproj
+++ b/Pilot.xcodeproj/project.pbxproj
@@ -122,6 +122,8 @@
 		8E0E6F291EE89A3D00D1CB86 /* SortedModelCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E0E6F271EE89A3D00D1CB86 /* SortedModelCollectionTests.swift */; };
 		9CA5FC4E1FB9A65300F85B98 /* CollectionViewHostReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA5FC4D1FB9A65300F85B98 /* CollectionViewHostReusableView.swift */; };
 		9CA5FC521FB9A81A00F85B98 /* CollectionViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA5FC511FB9A81A00F85B98 /* CollectionViewTests.swift */; };
+		A4002D36208F933F00B95A90 /* ModelCollectionStateViewTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4002D35208F933F00B95A90 /* ModelCollectionStateViewTypes.swift */; };
+		A4002D38208F937A00B95A90 /* ModelCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4002D37208F937A00B95A90 /* ModelCollectionViewController.swift */; };
 		A428996E1FA137F300EA4422 /* SecondaryActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A428996D1FA137F300EA4422 /* SecondaryActionInfo.swift */; };
 		A428996F1FA137F300EA4422 /* SecondaryActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A428996D1FA137F300EA4422 /* SecondaryActionInfo.swift */; };
 		A42899711FA1393500EA4422 /* ViewModelBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42899701FA1393500EA4422 /* ViewModelBinding.swift */; };
@@ -291,6 +293,8 @@
 		8E0E6F271EE89A3D00D1CB86 /* SortedModelCollectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortedModelCollectionTests.swift; sourceTree = "<group>"; };
 		9CA5FC4D1FB9A65300F85B98 /* CollectionViewHostReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewHostReusableView.swift; sourceTree = "<group>"; };
 		9CA5FC511FB9A81A00F85B98 /* CollectionViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewTests.swift; sourceTree = "<group>"; };
+		A4002D35208F933F00B95A90 /* ModelCollectionStateViewTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCollectionStateViewTypes.swift; sourceTree = "<group>"; };
+		A4002D37208F937A00B95A90 /* ModelCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCollectionViewController.swift; sourceTree = "<group>"; };
 		A428996D1FA137F300EA4422 /* SecondaryActionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryActionInfo.swift; sourceTree = "<group>"; };
 		A42899701FA1393500EA4422 /* ViewModelBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelBinding.swift; sourceTree = "<group>"; };
 		A437EDA71E56507600F67B37 /* SimpleModelCollectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimpleModelCollectionTests.swift; sourceTree = "<group>"; };
@@ -510,6 +514,7 @@
 		69048A4D1C470489000CE840 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				A4002D33208F931800B95A90 /* Common */,
 				3C6C9E211F31254F00D13B52 /* Alerts */,
 				697D0FCC1D37006300310F81 /* AppKitExtensions */,
 				69048A9A1C470F08000CE840 /* CollectionViews */,
@@ -660,6 +665,23 @@
 			isa = PBXGroup;
 			children = (
 				9CA5FC511FB9A81A00F85B98 /* CollectionViewTests.swift */,
+			);
+			path = mac;
+			sourceTree = "<group>";
+		};
+		A4002D33208F931800B95A90 /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				A4002D34208F932000B95A90 /* mac */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
+		A4002D34208F932000B95A90 /* mac */ = {
+			isa = PBXGroup;
+			children = (
+				A4002D35208F933F00B95A90 /* ModelCollectionStateViewTypes.swift */,
+				A4002D37208F937A00B95A90 /* ModelCollectionViewController.swift */,
 			);
 			path = mac;
 			sourceTree = "<group>";
@@ -1200,8 +1222,10 @@
 				69FADC8A1D30B7FC001F2E11 /* CollectionHostedView.swift in Sources */,
 				690E1AA11E54C0E100B257CA /* NSMenu+Action.swift in Sources */,
 				697D0FCE1D37008D00310F81 /* NSEvent+Keys.swift in Sources */,
+				A4002D36208F933F00B95A90 /* ModelCollectionStateViewTypes.swift in Sources */,
 				690E1AA71E54CAA000B257CA /* Collection.swift in Sources */,
 				E725E2EF206C5FF200786A12 /* NestableScrollView.swift in Sources */,
+				A4002D38208F937A00B95A90 /* ModelCollectionViewController.swift in Sources */,
 				69FADC591D306AF4001F2E11 /* CollectionViewController.swift in Sources */,
 				69FADC8D1D30BBF0001F2E11 /* CollectionViewInternals.swift in Sources */,
 				690E1AA51E54CAA000B257CA /* AssociatedObjects.swift in Sources */,

--- a/UI/Source/CollectionViews/mac/CollectionViewController.swift
+++ b/UI/Source/CollectionViews/mac/CollectionViewController.swift
@@ -1,50 +1,10 @@
 import AppKit
 import Pilot
 
-/// Struct representing what to display when the collection view is empty.
-public enum EmptyCollectionDisplay {
-    /// Returns a custom string with font and color, which is displayed in the center of the empty collection view.
-    case text(String, NSFont, NSColor)
-
-    /// Returns a custom view that will be centered in the empty collection view.
-    case view(NSView)
-
-    /// Returns a custom view and a custom constraint creation block to hook up constraints to the parent view.
-    /// Paramaters of the closure are the parent view and the child view, in order. Return value is an
-    /// array of constraints which will be added.
-    case viewWithCustomConstraints(NSView, (NSView, NSView) -> [NSLayoutConstraint])
-
-    /// No empty view.
-    case none
-}
-
-/// Struct representing what spinner to display when the collection view is empty and loading.
-/// TODO:(wkiefer) Bring this to iOS (and share where possible).
-public enum LoadingCollectionDisplay {
-    /// No loading view.
-    case none
-
-    /// Shows the default system spinner centered in the view.
-    case systemSpinner
-
-    /// Shows the default system spinner with the provided custom constraints.
-    /// Paramaters of the closure are the parent view and the child view, in order. Return value is an
-    /// array of constraints which will be added.
-    case systemSpinnerWithConstraints((NSView, NSView) -> [NSLayoutConstraint])
-
-    /// Shows a custom loading indicator view centered in the view.
-    case custom(NSView)
-
-    /// Shows a custom loading indicator view with the provided custom constraints.
-    /// Paramaters of the closure are the parent view and the child view, in order. Return value is an
-    /// array of constraints which will be added.
-    case customWithConstraints(NSView, (NSView, NSView) -> [NSLayoutConstraint])
-}
-
 /// View controller implementation which contains the core MVVM binding support to show a given `ModelCollection`
 /// in a collection view.
 /// Subclassing should typically be only for app-specific view controller behavior (and not cell configuration).
-open class CollectionViewController: NSViewController, CollectionViewDelegate {
+open class CollectionViewController: ModelCollectionViewController, CollectionViewDelegate {
 
     // MARK: Init
 
@@ -64,19 +24,11 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
             context: context.newScope(),
             reuseIdProvider: reuseIdProvider)
         self.modelBinder = modelBinder
-
-        super.init(nibName: nil, bundle: nil)
-    }
-
-    @available(*, unavailable,
-        message: "Use `init(model:modelBinder:viewBinder:layout:context:)`")
-    public required init?(coder: NSCoder) {
-        Log.fatal(message: "Use `init(model:modelBinder:viewBinder:layout:context:)` instead")
+        super.init(model: dataSource.currentCollection, context: dataSource.context)
     }
 
     deinit {
         unreigsterForMenuTrackingEnd()
-        unregisterForModelEvents()
         collectionView.delegate = nil
         collectionView.dataSource = nil
     }
@@ -91,13 +43,12 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
         return dataSource.currentCollection
     }
 
-    /// Read-only access to the underlying context.
-    public var context: Context {
-        return dataSource.context
-    }
-
     /// Read-only access to the collection view data source.
     public let dataSource: CollectionViewModelDataSource
+
+    public func model(at indexPath: IndexPath) -> Model {
+        return dataSource.currentCollection.sections[indexPath.section][indexPath.item]
+    }
 
     /// Layout for the collection view.
     open var layout: NSCollectionViewLayout {
@@ -117,85 +68,9 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
     /// Read-only access to the underlying collection view.
     open let collectionView: CollectionView = CollectionView()
 
-    /// Read-only access to the underlying scroll view.
-    open var scrollView: NSScrollView {
-        if let scrollView = internalScrollView { return scrollView }
+    // MARK: ModelCollectionViewController
 
-        let scrollView = makeScrollView()
-        internalScrollView = scrollView
-        return scrollView
-    }
-
-    /// Enables or disables scrolling on the hosted scrollview.
-    open var scrollEnabled: Bool {
-        get {
-            guard let scrollView = scrollView as? NestableScrollView else { return false }
-            return scrollView.scrollEnabled
-        }
-        set {
-            guard let scrollView = scrollView as? NestableScrollView else { return }
-            scrollView.scrollEnabled = newValue
-        }
-    }
-
-    /// Determines what should be displayed for an empty collection that is loading.
-    open var loadingDisplay: LoadingCollectionDisplay = .systemSpinner
-
-    // MARK: Public Intended for subclass override
-
-    /// Returns the root view created during `loadView`. Subclasses may override to provide their own customized
-    /// view instance.
-    open func makeRootView() -> NSView {
-        return NSView()
-    }
-
-    /// Returns the scrollView view created during `loadView`. Subclasses may override to provide their own customized
-    /// scrollView instance.
-    open func makeScrollView() -> NSScrollView {
-        return FullWidthScrollView()
-    }
-
-    /// Returns an `EmptyCollectionDisplay` struct defining what to show for an empty collection in the `Error` state.
-    /// Intended for subclass override.
-    open func displayForErrorState(_ error: Error) -> EmptyCollectionDisplay {
-        return .none
-    }
-
-    /// Returns an `EmptyCollectionDisplay` struct defining what to show for an empty collection that has no data but
-    /// is in the `Loaded` state. Intended for subclass override.
-    open func displayForNoContentState() -> EmptyCollectionDisplay {
-        return .none
-    }
-
-    /// Intended for subclass override - invoked when a model object is displayed in the collection.
-    open func willDisplayViewModel(_ viewModel: ViewModel) {
-        // NOP - intended for subclassing.
-    }
-
-    public func model(at indexPath: IndexPath) -> Model {
-        return dataSource.currentCollection.sections[indexPath.section][indexPath.item]
-    }
-
-    // MARK: NSViewController
-
-    public final override func loadView() {
-        view = makeRootView()
-        view.autoresizingMask = [.width, .height]
-
-        view.addSubview(scrollView)
-        scrollView.frame = view.bounds
-        scrollView.autoresizingMask = [.width, .height]
-
-        scrollView.wantsLayer = true
-        scrollView.layerContentsRedrawPolicy = .onSetNeedsDisplay
-
-        scrollView.horizontalScroller = FullWidthScroller()
-        scrollView.verticalScroller = FullWidthScroller()
-
-        scrollView.documentView = collectionView
-        scrollView.drawsBackground = false
-        scrollView.contentView.copiesOnScroll = true
-
+    internal final override func makeDocumentView() -> NSView {
         collectionView.wantsLayer = true
         collectionView.layerContentsRedrawPolicy = .onSetNeedsDisplay
 
@@ -204,7 +79,10 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
         collectionView.itemPrototype = nil
         collectionView.isSelectable = true
         collectionView.autoresizingMask = [.width, .height]
+        return collectionView
     }
+
+    // MARK: NSViewController
 
     open override func viewDidLoad() {
         super.viewDidLoad()
@@ -223,7 +101,6 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
         }
 
         scrollView.scrollerStyle = .overlay
-        registerForModelEvents()
     }
 
     open override func viewWillLayout() {
@@ -321,7 +198,6 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
     // MARK: Private
 
     private var lastBounds = CGRect.zero
-    private var internalScrollView: NSScrollView?
     private var modelBinder: ViewModelBindingProvider
 
     private func viewModelAtIndexPath(_ indexPath: IndexPath) -> ViewModel? {
@@ -343,70 +219,6 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
         let selectedModels = collectionView.selectionIndexPaths
             .map { dataSource.currentCollection.sections[$0.section][$0.item] }
         return modelBinder.selectionViewModel(for: selectedModels, context: context)
-    }
-
-    /// View to show when in the `loading` state - dictated by `loadingDisplay`.
-    private var loadingView: NSView?
-
-    private func showLoadingView() {
-        guard self.loadingView == nil else { return }
-        guard let loadingView = loadingView(for: loadingDisplay) else { return }
-
-        self.loadingView = loadingView
-
-        loadingView.translatesAutoresizingMaskIntoConstraints = false
-        collectionView.addSubview(loadingView)
-
-        let makeConstraints = loadingViewConstraints(for: loadingDisplay)
-        NSLayoutConstraint.activate(makeConstraints(view, loadingView))
-    }
-
-    private func hideLoadingView() {
-        loadingView?.removeFromSuperview()
-        loadingView = nil
-    }
-
-    private func loadingView(for display: LoadingCollectionDisplay) -> NSView? {
-        switch display {
-        case .none:
-            return nil
-        case .custom(let view):
-            return view
-        case .customWithConstraints(let view, _):
-            return view
-        case .systemSpinnerWithConstraints(_):
-            fallthrough
-        case .systemSpinner:
-            let spinner = NSProgressIndicator()
-            spinner.style = .spinning
-            spinner.controlSize = .small
-            spinner.startAnimation(self)
-            return spinner
-        }
-    }
-
-    private func loadingViewConstraints(
-        for display: LoadingCollectionDisplay
-    ) -> (NSView, NSView) -> [NSLayoutConstraint] {
-        let defaultConstraints: (NSView, NSView) -> [NSLayoutConstraint] = { parent, child in
-            return [child.centerXAnchor.constraint(equalTo: parent.centerXAnchor),
-                    child.centerYAnchor.constraint(equalTo: parent.centerYAnchor),
-                    child.bottomAnchor.constraint(lessThanOrEqualTo: parent.bottomAnchor),
-                    child.topAnchor.constraint(greaterThanOrEqualTo: parent.topAnchor)]
-        }
-
-        switch display {
-        case .custom(_):
-            return defaultConstraints
-        case .customWithConstraints(_, let constraints):
-            return constraints
-        case .none:
-            return { _, _ in return [] }
-        case .systemSpinner:
-            return defaultConstraints
-        case .systemSpinnerWithConstraints(let constraints):
-            return constraints
-        }
     }
 
     @objc
@@ -448,193 +260,5 @@ open class CollectionViewController: NSViewController, CollectionViewDelegate {
     @objc
     private func copy(_ sender: Any) {
         selectedViewModel()?.handleUserEvent(.copy)
-    }
-
-    // MARK: Observing model state changes.
-
-    private var collectionObserver: Observer?
-
-    private func registerForModelEvents() {
-        assertWithLog(collectionObserver == nil, message: "Expected to start with a nil token")
-
-        collectionObserver = collection.observe { [weak self] event in
-            self?.handleModelEvent(event)
-        }
-
-        // Upon registering, fire an initial state change to match existing state.
-        handleModelEvent(.didChangeState(collection.state))
-    }
-
-    private func unregisterForModelEvents() {
-        collectionObserver = nil
-    }
-
-    private func handleModelEvent(_ event: CollectionEvent) {
-        hideEmptyContentView()
-
-        switch event {
-        case .didChangeState(let state):
-            if !state.isLoading {
-                // Non-loading states should hide the spinner.
-                hideLoadingView()
-            }
-
-            switch state {
-            case .notLoaded:
-                break
-            case .loading(let models):
-                if models == nil || state.isEmpty {
-                    showLoadingView()
-                }
-            case .loaded:
-                updateEmptyContentViewVisibility()
-            case .error(_):
-                updateEmptyContentViewVisibility()
-            }
-        }
-    }
-
-    /// View which is displayed when there is no content (either due to error or lack of loaded data).
-    private var emptyContentView: NSView?
-
-    private func showEmptyContentView() {
-        guard self.emptyContentView == nil else { return }
-
-        let display: EmptyCollectionDisplay
-        if case .error(let error) = collection.state {
-            display = displayForErrorState(error)
-        } else {
-            display = displayForNoContentState()
-        }
-
-        if let emptyContentView = emptyContentView(for: display) {
-            self.emptyContentView = emptyContentView
-
-            emptyContentView.translatesAutoresizingMaskIntoConstraints = false
-            view.addSubview(emptyContentView)
-
-            let makeConstraints = emptyContentViewConstraints(for: display)
-            NSLayoutConstraint.activate(makeConstraints(view, emptyContentView))
-        }
-    }
-
-    private func hideEmptyContentView() {
-        emptyContentView?.removeFromSuperview()
-        emptyContentView = nil
-    }
-
-    private func updateEmptyContentViewVisibility() {
-        switch collection.state {
-        case .error(_), .loaded:
-            if collection.state.isEmpty {
-                showEmptyContentView()
-            } else {
-                hideEmptyContentView()
-            }
-        case .notLoaded, .loading:
-            hideEmptyContentView()
-        }
-    }
-
-    private func emptyContentView(for display: EmptyCollectionDisplay) -> NSView? {
-        switch display {
-        case .none:
-            return nil
-        case .text(let string, let font, let color):
-            let label = NSTextField()
-            label.isEditable = false
-            label.isBordered = false
-            label.backgroundColor = .clear
-            label.alignment = .center
-            label.font = font
-            label.textColor = color
-            label.stringValue = string
-            return label
-        case .viewWithCustomConstraints(let view, _):
-            return view
-        case .view(let view):
-            return view
-        }
-    }
-
-    private func emptyContentViewConstraints(
-        for display: EmptyCollectionDisplay
-    ) -> (NSView, NSView) -> [NSLayoutConstraint] {
-        switch display {
-        case .viewWithCustomConstraints(_, let constraints):
-            return constraints
-        case .text(_, _, _):
-            return { parent, child in
-                return [child.widthAnchor.constraint(equalTo: parent.widthAnchor),
-                        child.heightAnchor.constraint(lessThanOrEqualTo: parent.widthAnchor),
-                        child.centerXAnchor.constraint(equalTo: parent.centerXAnchor),
-                        child.centerYAnchor.constraint(equalTo: parent.centerYAnchor)]
-            }
-        default:
-            return { parent, child in
-                return [child.centerXAnchor.constraint(equalTo: parent.centerXAnchor),
-                        child.centerYAnchor.constraint(equalTo: parent.centerYAnchor)]
-            }
-        }
-    }
-}
-
-// MARK: -
-
-/// Private helper class to force the scroller to always appear as a modern over-content scroller.
-private final class FullWidthScroller: NSScroller {
-
-    // MARK: NSScroller
-
-    override class var isCompatibleWithOverlayScrollers: Bool {
-        return true
-    }
-
-    override class var preferredScrollerStyle: NSScroller.Style {
-        return .overlay
-    }
-
-    override func drawKnobSlot(in slotRect: NSRect, highlight flag: Bool) {
-        // Nop
-    }
-
-    override class func scrollerWidth(
-        for controlSize: NSControl.ControlSize,
-        scrollerStyle: NSScroller.Style
-    ) -> CGFloat {
-        if FullWidthScroller.widthOverride {
-            return 0.0
-        }
-        return super.scrollerWidth(for: controlSize, scrollerStyle: scrollerStyle)
-    }
-
-    // MARK: Private
-
-    static var widthOverride = false
-}
-
-/// Private helper class to force the vertical scroller to always appear as a modern over-content scroller.
-private final class FullWidthScrollView: NestableScrollView {
-
-    fileprivate override func tile() {
-        // For the superclass's tile implementation, the scroller returns zero width so content underneath is always
-        // full width.
-        FullWidthScroller.widthOverride = true
-        super.tile()
-        FullWidthScroller.widthOverride = false
-
-        guard let verticalScroller = verticalScroller else { return }
-
-        // Now adjust the actual scroller frame since the `super.tile()` call made it zero width.
-        let bounds = self.bounds
-        let vInset = contentInsets
-        let vWidth = FullWidthScroller.scrollerWidth(
-            for: verticalScroller.controlSize,
-            scrollerStyle: verticalScroller.scrollerStyle)
-        verticalScroller.frame = CGRect(
-            x: bounds.width - vWidth - vInset.right,
-            y: vInset.top,
-            width: vWidth,
-            height: bounds.height - vInset.top - vInset.bottom)
     }
 }

--- a/UI/Source/CollectionViews/mac/CollectionViewController.swift
+++ b/UI/Source/CollectionViews/mac/CollectionViewController.swift
@@ -70,7 +70,7 @@ open class CollectionViewController: ModelCollectionViewController, CollectionVi
 
     // MARK: ModelCollectionViewController
 
-    internal final override func makeDocumentView() -> NSView {
+    public final override func makeDocumentView() -> NSView {
         collectionView.wantsLayer = true
         collectionView.layerContentsRedrawPolicy = .onSetNeedsDisplay
 

--- a/UI/Source/Common/mac/ModelCollectionStateViewTypes.swift
+++ b/UI/Source/Common/mac/ModelCollectionStateViewTypes.swift
@@ -1,0 +1,41 @@
+import AppKit
+
+/// Struct representing what to display when the collection view is empty.
+public enum EmptyCollectionDisplay {
+    /// Returns a custom string with font and color, which is displayed in the center of the empty collection view.
+    case text(String, NSFont, NSColor)
+
+    /// Returns a custom view that will be centered in the empty collection view.
+    case view(NSView)
+
+    /// Returns a custom view and a custom constraint creation block to hook up constraints to the parent view.
+    /// Paramaters of the closure are the parent view and the child view, in order. Return value is an
+    /// array of constraints which will be added.
+    case viewWithCustomConstraints(NSView, (NSView, NSView) -> [NSLayoutConstraint])
+
+    /// No empty view.
+    case none
+}
+
+/// Struct representing what spinner to display when the collection view is empty and loading.
+/// TODO:(wkiefer) Bring this to iOS (and share where possible).
+public enum LoadingCollectionDisplay {
+    /// No loading view.
+    case none
+
+    /// Shows the default system spinner centered in the view.
+    case systemSpinner
+
+    /// Shows the default system spinner with the provided custom constraints.
+    /// Paramaters of the closure are the parent view and the child view, in order. Return value is an
+    /// array of constraints which will be added.
+    case systemSpinnerWithConstraints((NSView, NSView) -> [NSLayoutConstraint])
+
+    /// Shows a custom loading indicator view centered in the view.
+    case custom(NSView)
+
+    /// Shows a custom loading indicator view with the provided custom constraints.
+    /// Paramaters of the closure are the parent view and the child view, in order. Return value is an
+    /// array of constraints which will be added.
+    case customWithConstraints(NSView, (NSView, NSView) -> [NSLayoutConstraint])
+}

--- a/UI/Source/Common/mac/ModelCollectionViewController.swift
+++ b/UI/Source/Common/mac/ModelCollectionViewController.swift
@@ -1,0 +1,386 @@
+import AppKit
+import Pilot
+
+/// Common view controller to support a scrollable views of a ModelCollection.
+open class ModelCollectionViewController: NSViewController {
+
+    public init(model: ModelCollection, context: Context) {
+        self.model = model
+        self.context = context
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable, message: "Use `init(model:modelBinder:viewBinder:layout:context:)`")
+    public required init?(coder: NSCoder) {
+        Log.fatal(message: "Use `init(model:modelBinder:viewBinder:layout:context:)` instead")
+    }
+
+    deinit {
+        unregisterForModelEvents()
+    }
+
+    // MARK: Open functions for subclasses to customize.
+
+    /// Determines what should be displayed for an empty collection that is loading.
+    open var loadingDisplay: LoadingCollectionDisplay = .systemSpinner
+
+    /// Returns the root view created during `loadView`. Subclasses may override to provide their own customized
+    /// view instance.
+    open func makeRootView() -> NSView {
+        return NSView()
+    }
+
+    /// Returns the scrollView view created during `loadView`. Subclasses may override to provide their own customized
+    /// scrollView instance.
+    open func makeScrollView() -> NSScrollView {
+        return FullWidthScrollView()
+    }
+
+    /// Returns an `EmptyCollectionDisplay` struct defining what to show for an empty collection in the `Error` state.
+    /// Intended for subclass override.
+    open func displayForErrorState(_ error: Error) -> EmptyCollectionDisplay {
+        return .none
+    }
+
+    /// Returns an `EmptyCollectionDisplay` struct defining what to show for an empty collection that has no data but
+    /// is in the `Loaded` state. Intended for subclass override.
+    open func displayForNoContentState() -> EmptyCollectionDisplay {
+        return .none
+    }
+
+    /// Intended for subclass override - invoked when a model object is displayed in the collection.
+    open func willDisplayViewModel(_ viewModel: ViewModel) {
+        // NOP - intended for subclassing.
+    }
+
+    /// Read-only access to the underlying scroll view.
+    open var scrollView: NSScrollView {
+        if let scrollView = internalScrollView { return scrollView }
+
+        let scrollView = makeScrollView()
+        internalScrollView = scrollView
+        return scrollView
+    }
+
+    /// Enables or disables scrolling on the hosted scrollview iff it's a NestableScrollView.
+    open var scrollEnabled: Bool {
+        get {
+            guard let scrollView = scrollView as? NestableScrollView else { return false }
+            return scrollView.scrollEnabled
+        }
+        set {
+            guard let scrollView = scrollView as? NestableScrollView else { return }
+            scrollView.scrollEnabled = newValue
+        }
+    }
+
+    // MARK: Public
+
+    public let model: ModelCollection
+    public let context: Context
+
+    // MARK: NSViewController
+
+    public final override func loadView() {
+        view = makeRootView()
+        view.autoresizingMask = [.width, .height]
+
+        view.addSubview(scrollView)
+        scrollView.frame = view.bounds
+        scrollView.autoresizingMask = [.width, .height]
+
+        scrollView.wantsLayer = true
+        scrollView.layerContentsRedrawPolicy = .onSetNeedsDisplay
+
+        scrollView.horizontalScroller = FullWidthScroller()
+        scrollView.verticalScroller = FullWidthScroller()
+
+        scrollView.documentView = makeDocumentView()
+        scrollView.drawsBackground = false
+        scrollView.contentView.copiesOnScroll = true
+    }
+
+    open override func viewDidLoad() {
+        super.viewDidLoad()
+        registerForModelEvents()
+    }
+
+    // MARK: Internal
+
+    /// Intended to be overridden by subclass. Returns the documentView of the scrollView, called once during loadView.
+    internal func makeDocumentView() -> NSView {
+        return NSView()
+    }
+
+    // MARK: Private
+
+    private var internalScrollView: NSScrollView?
+
+    /// View which is displayed when there is no content (either due to error or lack of loaded data).
+    private var emptyContentView: NSView?
+
+    private func showEmptyContentView() {
+        guard self.emptyContentView == nil else { return }
+
+        let display: EmptyCollectionDisplay
+        if case .error(let error) = model.state {
+            display = displayForErrorState(error)
+        } else {
+            display = displayForNoContentState()
+        }
+
+        if let emptyContentView = emptyContentView(for: display) {
+            self.emptyContentView = emptyContentView
+
+            emptyContentView.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview(emptyContentView)
+
+            let makeConstraints = emptyContentViewConstraints(for: display)
+            NSLayoutConstraint.activate(makeConstraints(view, emptyContentView))
+        }
+    }
+
+    private func hideEmptyContentView() {
+        emptyContentView?.removeFromSuperview()
+        emptyContentView = nil
+    }
+
+    private func updateEmptyContentViewVisibility() {
+        switch model.state {
+        case .error, .loaded:
+            if model.state.isEmpty {
+                showEmptyContentView()
+            } else {
+                hideEmptyContentView()
+            }
+        case .notLoaded, .loading:
+            hideEmptyContentView()
+        }
+    }
+
+    private func emptyContentView(for display: EmptyCollectionDisplay) -> NSView? {
+        switch display {
+        case .none:
+            return nil
+        case .text(let string, let font, let color):
+            let label = NSTextField()
+            label.isEditable = false
+            label.isBordered = false
+            label.backgroundColor = .clear
+            label.alignment = .center
+            label.font = font
+            label.textColor = color
+            label.stringValue = string
+            return label
+        case .viewWithCustomConstraints(let view, _):
+            return view
+        case .view(let view):
+            return view
+        }
+    }
+
+    private func emptyContentViewConstraints(
+        for display: EmptyCollectionDisplay
+    ) -> (NSView, NSView) -> [NSLayoutConstraint] {
+        switch display {
+        case .viewWithCustomConstraints(_, let constraints):
+            return constraints
+        case .text(_, _, _):
+            return { parent, child in
+                return [child.widthAnchor.constraint(equalTo: parent.widthAnchor),
+                        child.heightAnchor.constraint(lessThanOrEqualTo: parent.widthAnchor),
+                        child.centerXAnchor.constraint(equalTo: parent.centerXAnchor),
+                        child.centerYAnchor.constraint(equalTo: parent.centerYAnchor)]
+            }
+        default:
+            return { parent, child in
+                return [child.centerXAnchor.constraint(equalTo: parent.centerXAnchor),
+                        child.centerYAnchor.constraint(equalTo: parent.centerYAnchor)]
+            }
+        }
+    }
+
+    /// View to show when in the `loading` state - dictated by `loadingDisplay`.
+    private var loadingView: NSView?
+
+    private func showLoadingView() {
+        guard self.loadingView == nil else { return }
+        guard let loadingView = loadingView(for: loadingDisplay) else { return }
+
+        self.loadingView = loadingView
+
+        loadingView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.documentView?.addSubview(loadingView)
+
+        let makeConstraints = loadingViewConstraints(for: loadingDisplay)
+        NSLayoutConstraint.activate(makeConstraints(view, loadingView))
+    }
+
+    private func loadingViewConstraints(
+        for display: LoadingCollectionDisplay
+    ) -> (NSView, NSView) -> [NSLayoutConstraint] {
+        let defaultConstraints: (NSView, NSView) -> [NSLayoutConstraint] = { parent, child in
+            return [child.centerXAnchor.constraint(equalTo: parent.centerXAnchor),
+                    child.centerYAnchor.constraint(equalTo: parent.centerYAnchor),
+                    child.bottomAnchor.constraint(lessThanOrEqualTo: parent.bottomAnchor),
+                    child.topAnchor.constraint(greaterThanOrEqualTo: parent.topAnchor)]
+        }
+
+        switch display {
+        case .custom(_):
+            return defaultConstraints
+        case .customWithConstraints(_, let constraints):
+            return constraints
+        case .none:
+            return { _, _ in return [] }
+        case .systemSpinner:
+            return defaultConstraints
+        case .systemSpinnerWithConstraints(let constraints):
+            return constraints
+        }
+    }
+
+    private func hideLoadingView() {
+        loadingView?.removeFromSuperview()
+        loadingView = nil
+    }
+
+    private func loadingView(for display: LoadingCollectionDisplay) -> NSView? {
+        switch display {
+        case .none:
+            return nil
+        case .custom(let view):
+            return view
+        case .customWithConstraints(let view, _):
+            return view
+        case .systemSpinnerWithConstraints(_):
+            fallthrough
+        case .systemSpinner:
+            let spinner = NSProgressIndicator()
+            spinner.style = .spinning
+            spinner.controlSize = .small
+            spinner.startAnimation(self)
+            return spinner
+        }
+    }
+
+    // MARK: Observing model state changes.
+
+    private var collectionObserver: Observer?
+
+    private func registerForModelEvents() {
+        assertWithLog(collectionObserver == nil, message: "Expected to start with a nil token")
+
+        collectionObserver = model.observe { [weak self] event in
+            self?.handleModelEvent(event)
+        }
+
+        // Upon registering, fire an initial state change to match existing state.
+        handleModelEvent(.didChangeState(model.state))
+    }
+
+    private func unregisterForModelEvents() {
+        collectionObserver = nil
+    }
+
+    private func handleModelEvent(_ event: CollectionEvent) {
+        hideEmptyContentView()
+
+        switch event {
+        case .didChangeState(let state):
+            if !state.isLoading {
+                // Non-loading states should hide the spinner.
+                hideLoadingView()
+            }
+
+            switch state {
+            case .notLoaded:
+                break
+            case .loading(let models):
+                if models == nil || state.isEmpty {
+                    showLoadingView()
+                }
+            case .loaded:
+                updateEmptyContentViewVisibility()
+            case .error(_):
+                updateEmptyContentViewVisibility()
+            }
+        }
+    }
+}
+
+// MARK: -
+
+/// Private helper class to force the scroller to always appear as a modern over-content scroller.
+private final class FullWidthScroller: NSScroller {
+
+    // MARK: NSScroller
+
+    override class var isCompatibleWithOverlayScrollers: Bool {
+        return true
+    }
+
+    override class var preferredScrollerStyle: NSScroller.Style {
+        return .overlay
+    }
+
+    override func drawKnobSlot(in slotRect: NSRect, highlight flag: Bool) {
+        // Nop
+    }
+
+    override class func scrollerWidth(
+        for controlSize: NSControl.ControlSize,
+        scrollerStyle: NSScroller.Style
+    ) -> CGFloat {
+        if FullWidthScroller.widthOverride {
+            return 0.0
+        }
+        return super.scrollerWidth(for: controlSize, scrollerStyle: scrollerStyle)
+    }
+
+    // MARK: Private
+
+    static var widthOverride = false
+}
+
+/// Private helper class to force the vertical scroller to always appear as a modern over-content scroller.
+private final class FullWidthScrollView: NSScrollView {
+
+    fileprivate var scrollEnabled: Bool = true
+
+    // MARK: NSScrollView
+
+    fileprivate override func scrollWheel(with theEvent: NSEvent) {
+        if scrollEnabled {
+            super.scrollWheel(with: theEvent)
+        }
+    }
+
+    fileprivate override func flashScrollers() {
+        if scrollEnabled {
+            super.flashScrollers()
+        }
+    }
+
+    fileprivate override func tile() {
+        // For the superclass's tile implementation, the scroller returns zero width so content underneath is always
+        // full width.
+        FullWidthScroller.widthOverride = true
+        super.tile()
+        FullWidthScroller.widthOverride = false
+
+        guard let verticalScroller = verticalScroller else { return }
+
+        // Now adjust the actual scroller frame since the `super.tile()` call made it zero width.
+        let bounds = self.bounds
+        let vInset = contentInsets
+        let vWidth = FullWidthScroller.scrollerWidth(
+            for: verticalScroller.controlSize,
+            scrollerStyle: verticalScroller.scrollerStyle)
+        verticalScroller.frame = CGRect(
+            x: bounds.width - vWidth - vInset.right,
+            y: vInset.top,
+            width: vWidth,
+            height: bounds.height - vInset.top - vInset.bottom)
+    }
+}

--- a/UI/Source/Common/mac/ModelCollectionViewController.swift
+++ b/UI/Source/Common/mac/ModelCollectionViewController.swift
@@ -2,7 +2,10 @@ import AppKit
 import Pilot
 
 /// Common view controller to support a scrollable views of a ModelCollection.
-public class ModelCollectionViewController: NSViewController {
+///
+/// Note: this is open to facilitate subclassing with open classes like CollectionViewController, but isn't intended or
+/// useful to subclass this class directly outside of PilotUI.
+open class ModelCollectionViewController: NSViewController {
 
     public init(model: ModelCollection, context: Context) {
         self.model = model

--- a/UI/Source/Common/mac/ModelCollectionViewController.swift
+++ b/UI/Source/Common/mac/ModelCollectionViewController.swift
@@ -2,7 +2,7 @@ import AppKit
 import Pilot
 
 /// Common view controller to support a scrollable views of a ModelCollection.
-open class ModelCollectionViewController: NSViewController {
+public class ModelCollectionViewController: NSViewController {
 
     public init(model: ModelCollection, context: Context) {
         self.model = model

--- a/UI/Source/Common/mac/ModelCollectionViewController.swift
+++ b/UI/Source/Common/mac/ModelCollectionViewController.swift
@@ -105,10 +105,9 @@ open class ModelCollectionViewController: NSViewController {
         registerForModelEvents()
     }
 
-    // MARK: Internal
-
     /// Intended to be overridden by subclass. Returns the documentView of the scrollView, called once during loadView.
-    internal func makeDocumentView() -> NSView {
+    // TODO:(danielh) This should be able to be internal, but linking fails on release builds when it is, file radar.
+    public func makeDocumentView() -> NSView {
         return NSView()
     }
 


### PR DESCRIPTION
Part of prep work for table and outline view support, there's a bunch of shared code for all potential types of scrollable views of a model collection. This just pulls out the non-CollectionView-specific parts of CollectionViewController into a superclass. Followup diff(s) will use this to create the OutlineViewController