### PR TITLE
[RFC] Call delegate for NSCollectionView+Selection methods.

### DIFF
--- a/UI/Source/AppKitExtensions/NSCollectionView+Selection.swift
+++ b/UI/Source/AppKitExtensions/NSCollectionView+Selection.swift
@@ -4,21 +4,21 @@ import Foundation
 public extension NSCollectionView {
 
     /// Sets the selection to the first item in the collection view, and calls the delegate's selection method.
-    public func selectFirstItem() {
+    public func selectFirstItem(notifyingDelegate: Bool = false) {
         for section in 0..<numberOfSections {
             if numberOfItems(inSection: section) > 0 {
-                setSingleSelection(0, section: section)
+                setSingleSelection(0, section: section, notifyingDelegate: notifyingDelegate)
                 return
             }
         }
     }
 
     /// Sets the selection to the last item in the collection view, and calls the delegate's selection method.
-    public func selectLastItem() {
+    public func selectLastItem(notifyingDelegate: Bool = false) {
         for section in (0..<numberOfSections).reversed() {
             let itemCount = numberOfItems(inSection: section)
             if itemCount > 0 {
-                setSingleSelection(itemCount - 1, section: section)
+                setSingleSelection(itemCount - 1, section: section, notifyingDelegate: notifyingDelegate)
                 return
             }
         }
@@ -26,7 +26,7 @@ public extension NSCollectionView {
 
     /// Sets the selection to item immediately following the current selection,
     /// and calls the delegate's selection method. Assumes the current selection has one item.
-    public func selectNextItem() {
+    public func selectNextItem(notifyingDelegate: Bool = false) {
         let sectionCount = numberOfSections
         if sectionCount == 0 { return }
 
@@ -50,12 +50,12 @@ public extension NSCollectionView {
             }
         }
 
-        setSingleSelection(currentPath.item, section: currentPath.section)
+        setSingleSelection(currentPath.item, section: currentPath.section, notifyingDelegate: notifyingDelegate)
     }
 
     /// Sets the selection to item immediately preceding the current selection,
     /// and calls the delegate's selection method. Assumes the current selection has one item.
-    public func selectPreviousItem() {
+    public func selectPreviousItem(notifyingDelegate: Bool = false) {
         let sectionCount = numberOfSections
         if sectionCount == 0 { return }
 
@@ -79,7 +79,7 @@ public extension NSCollectionView {
             currentPath.item = numberOfItems(inSection: currentPath.section) - 1
         }
 
-        setSingleSelection(currentPath.item, section: currentPath.section)
+        setSingleSelection(currentPath.item, section: currentPath.section, notifyingDelegate: notifyingDelegate)
     }
 
     /// Scrolls to nearest edge taking into account the host scoll view's content inset.
@@ -128,10 +128,13 @@ public extension NSCollectionView {
         return next as? NSScrollView
     }
 
-    private func setSingleSelection(_ item: Int, section: Int) {
+    private func setSingleSelection(_ item: Int, section: Int, notifyingDelegate: Bool) {
         let selectedIndexPath = IndexPath(forModelItem: item, inSection: section)
         selectionIndexPaths = [selectedIndexPath]
         verticallyScrollTo(itemAtIndexPath: selectedIndexPath)
-        self.delegate?.collectionView?(self, didSelectItemsAt: selectionIndexPaths)
+
+        if notifyingDelegate {
+            self.delegate?.collectionView?(self, didSelectItemsAt: selectionIndexPaths)
+        }
     }
 }

--- a/UI/Source/AppKitExtensions/NSCollectionView+Selection.swift
+++ b/UI/Source/AppKitExtensions/NSCollectionView+Selection.swift
@@ -3,7 +3,7 @@ import Foundation
 
 public extension NSCollectionView {
 
-    /// Sets the selection to the first item in the collection view.
+    /// Sets the selection to the first item in the collection view, and calls the delegate's selection method.
     public func selectFirstItem() {
         for section in 0..<numberOfSections {
             if numberOfItems(inSection: section) > 0 {
@@ -13,7 +13,7 @@ public extension NSCollectionView {
         }
     }
 
-    /// Sets the selection to the last item in the collection view.
+    /// Sets the selection to the last item in the collection view, and calls the delegate's selection method.
     public func selectLastItem() {
         for section in (0..<numberOfSections).reversed() {
             let itemCount = numberOfItems(inSection: section)
@@ -24,8 +24,8 @@ public extension NSCollectionView {
         }
     }
 
-    /// Sets the selection to item immediately following the current selection.
-    /// Assumes the current selection has one item.
+    /// Sets the selection to item immediately following the current selection,
+    /// and calls the delegate's selection method. Assumes the current selection has one item.
     public func selectNextItem() {
         let sectionCount = numberOfSections
         if sectionCount == 0 { return }
@@ -53,8 +53,8 @@ public extension NSCollectionView {
         setSingleSelection(currentPath.item, section: currentPath.section)
     }
 
-    /// Sets the selection to item immediately preceding the current selection.
-    /// Assumes the current selection has one item.
+    /// Sets the selection to item immediately preceding the current selection,
+    /// and calls the delegate's selection method. Assumes the current selection has one item.
     public func selectPreviousItem() {
         let sectionCount = numberOfSections
         if sectionCount == 0 { return }
@@ -132,5 +132,6 @@ public extension NSCollectionView {
         let selectedIndexPath = IndexPath(forModelItem: item, inSection: section)
         selectionIndexPaths = [selectedIndexPath]
         verticallyScrollTo(itemAtIndexPath: selectedIndexPath)
+        self.delegate?.collectionView?(self, didSelectItemsAt: selectionIndexPaths)
     }
 }

--- a/UI/Source/AppKitExtensions/NSCollectionView+Selection.swift
+++ b/UI/Source/AppKitExtensions/NSCollectionView+Selection.swift
@@ -3,7 +3,8 @@ import Foundation
 
 public extension NSCollectionView {
 
-    /// Sets the selection to the first item in the collection view, and calls the delegate's selection method.
+    /// Sets the selection to the first item in the collection view,
+    /// and optionally calls the delegate's selection method.
     public func selectFirstItem(notifyingDelegate: Bool = false) {
         for section in 0..<numberOfSections {
             if numberOfItems(inSection: section) > 0 {
@@ -13,7 +14,8 @@ public extension NSCollectionView {
         }
     }
 
-    /// Sets the selection to the last item in the collection view, and calls the delegate's selection method.
+    /// Sets the selection to the last item in the collection view,
+    /// and optionally calls the delegate's selection method.
     public func selectLastItem(notifyingDelegate: Bool = false) {
         for section in (0..<numberOfSections).reversed() {
             let itemCount = numberOfItems(inSection: section)
@@ -24,8 +26,8 @@ public extension NSCollectionView {
         }
     }
 
-    /// Sets the selection to item immediately following the current selection,
-    /// and calls the delegate's selection method. Assumes the current selection has one item.
+    /// Sets the selection to item immediately following the current selection, and optionally calls the delegate's
+    /// selection method. Assumes the current selection has one item.
     public func selectNextItem(notifyingDelegate: Bool = false) {
         let sectionCount = numberOfSections
         if sectionCount == 0 { return }
@@ -53,8 +55,8 @@ public extension NSCollectionView {
         setSingleSelection(currentPath.item, section: currentPath.section, notifyingDelegate: notifyingDelegate)
     }
 
-    /// Sets the selection to item immediately preceding the current selection,
-    /// and calls the delegate's selection method. Assumes the current selection has one item.
+    /// Sets the selection to item immediately preceding the current selection, and optionally calls the delegate's
+    /// selection method. Assumes the current selection has one item.
     public func selectPreviousItem(notifyingDelegate: Bool = false) {
         let sectionCount = numberOfSections
         if sectionCount == 0 { return }
@@ -134,7 +136,7 @@ public extension NSCollectionView {
         verticallyScrollTo(itemAtIndexPath: selectedIndexPath)
 
         if notifyingDelegate {
-            self.delegate?.collectionView?(self, didSelectItemsAt: selectionIndexPaths)
+            delegate?.collectionView?(self, didSelectItemsAt: selectionIndexPaths)
         }
     }
 }


### PR DESCRIPTION
Needed this tweak for chackday.

Per doc, `selectItems(at…` or assigning `selectionIndexPaths` directly does not call the delegate’s `collectionView(_:didSelectItemsAt:)`

But it also would be super gross to sprinkle`collectionView.delegate?.collectionView?(viewController.collectionView, didSelectItemsAt: strongSelf.viewController.collectionView.selectionIndexes)` at the call sites of `selectFooItem()`

It's even worse in `CollectionPopoverController`, which needs an additional `strongSelf.viewController.` prefix on those calls.

These methods seem high level enough that calling the delegate feels ok, as long as it’s documented. Thoughts?