### PR TITLE
Retain observation block object for real.

### DIFF
--- a/UI/Source/CollectionViews/mac/CollectionViewController.swift
+++ b/UI/Source/CollectionViews/mac/CollectionViewController.swift
@@ -242,7 +242,7 @@ open class CollectionViewController: ModelCollectionViewController, CollectionVi
 
         let cookie = item.menuTrackingCookie
 
-        NotificationCenter.default.addObserver(
+        menuNotificationObserver = NotificationCenter.default.addObserver(
             forName: NSMenu.didEndTrackingNotification,
             object: menu,
             queue: OperationQueue.main) { [weak item] _ in


### PR DESCRIPTION
The observation block wasn't being retained for `NSMenu.didEndTrackingNotification`. The block-based API doesn't get the same free registration removal as the selector-based API.