### PR TITLE
use model id path based items

### DIFF
--- a/Core/Source/MVVM/Model.swift
+++ b/Core/Source/MVVM/Model.swift
@@ -59,6 +59,15 @@ public struct ModelVersion: Equatable {
     fileprivate let hash2: UInt64
 }
 
+extension ModelVersion: ExpressibleByIntegerLiteral {
+    public typealias IntegerLiteralType = Int
+
+    public init(integerLiteral value: IntegerLiteralType) {
+        self.hash1 = UInt64(bitPattern: Int64(value))
+        self.hash2 = 0
+    }
+}
+
 public func ==(lhs: ModelVersion, rhs: ModelVersion) -> Bool {
     return lhs.hash1 == rhs.hash1 && lhs.hash2 == rhs.hash2
 }

--- a/Examples/DirectoryViewer/DirectoryViewer/AppDelegate.swift
+++ b/Examples/DirectoryViewer/DirectoryViewer/AppDelegate.swift
@@ -15,6 +15,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             url: FileManager.default.homeDirectoryForCurrentUser,
             context: rootContext)
         */
+
         window.contentViewController = DirectoryCollectionViewController(
             url: FileManager.default.homeDirectoryForCurrentUser,
             context: rootContext)

--- a/UI/Source/OutlineViews/mac/NestedModelCollectionTreeController.swift
+++ b/UI/Source/OutlineViews/mac/NestedModelCollectionTreeController.swift
@@ -10,6 +10,59 @@ import Pilot
 /// NOTE: NestedModelCollectionTreeController is considered == whenever the indexPath and ModelCollection ids are ==
 internal final class NestedModelCollectionTreeController: ProxyingObservable {
 
+    /// Opaque reference to a location of a node in the tree. NSObject subclass so this object can be used as the
+    /// item in all NSOutlineView/NSOutlineViewDataSource APIs.
+    internal class TreePath: NSObject {
+        override init() {
+            self.components = []
+            super.init()
+        }
+
+        fileprivate init(components: [ModelId]) {
+            self.components = components
+            super.init()
+        }
+
+        // MARK: Equatable
+
+        static func ==(lhs: TreePath, rhs: TreePath) -> Bool {
+            return lhs.components == rhs.components
+        }
+
+        // MARK: NSObject
+
+        override func isEqual(_ object: Any?) -> Bool {
+            if let other = object as? TreePath {
+                return other.components == components
+            }
+            return false
+        }
+
+        override var hash: Int {
+            var result = 0
+            for component in components { result = result ^ component.hash }
+            return result
+        }
+
+        // MARK: fileprivate
+
+        func dropFirst() -> TreePath {
+            return TreePath(components: Array(components.dropFirst()))
+        }
+
+        func dropLast() -> TreePath {
+            return TreePath(components: Array(components.dropLast()))
+        }
+
+        func appending(_ modelId: ModelId) -> TreePath {
+            return TreePath(components: components + [modelId])
+        }
+
+        fileprivate var components: [ModelId]
+    }
+
+    // MARK: Initialization
+
     internal convenience init(modelCollection: NestedModelCollection) {
         self.init(modelCollection: modelCollection, modelId: nil, parent: nil)
     }
@@ -29,38 +82,65 @@ internal final class NestedModelCollectionTreeController: ProxyingObservable {
         }
         // Update diff engine state up to current state of ModelCollection so future calls to .update get correct diffs.
         _ = diffEngine.update([modelCollection.models])
+        recreateModelCollectionCache()
         self.modelCollectionObserver = modelCollection.observe { [weak self] (event) in
             self?.handleCollectionEvent(event)
         }
     }
 
-    internal func isExpandable(_ path: IndexPath) -> Bool {
-        let model = modelAtIndexPath(path)
+    // MARK: Internal API
+
+    internal func isExpandable(_ path: TreePath) -> Bool {
+        let model = modelAtPath(path)
         let containingNode = findOrCreateNode(path.dropLast())
         return containingNode.modelCollection.canExpand(model)
     }
 
-    internal func countOfChildNodes(_ path: IndexPath) -> Int {
-        return findOrCreateNode(path).modelCollection.models.count
+    internal func numberOfChildren(_ path: TreePath?) -> Int {
+        return findOrCreateNode(path ?? TreePath()).modelCollection.models.count
     }
 
-    internal func modelAtIndexPath(_ path: IndexPath) -> Model {
-        guard !path.isEmpty else { Log.fatal(message: "Empty path passed to modelAtIndexPath()") }
+    internal func modelAtPath(_ path: TreePath) -> Model {
+        guard !path.components.isEmpty else { Log.fatal(message: "Empty path passed to modelAtIndexPath()") }
         let containingNode = findOrCreateNode(path.dropLast())
-        return containingNode.modelCollection.models[path.last!]
-    }
-
-    internal var indexPath: IndexPath {
-        // TODO:(danielh) This is very inefficient, though thankfully isn't called super often, optimize once there's
-        // enough test coverage to ensure correctness.
-        guard let parent = parent, let modelId = modelId else { return IndexPath() }
-        guard let index = parent.modelCollection.models.index(where: { $0.modelId == modelId }) else {
-            Log.fatal(message: "Parent of model collection no longer knows about child")
+        guard let model = containingNode.modelCollectionCache[path.components.last!]?.1 else {
+            Log.fatal(message: "modelAtPath requested for unknown 'path' \(path)")
         }
-        return parent.indexPath.appending(index)
+        return model
     }
 
-    internal weak var parent: NestedModelCollectionTreeController? = nil
+    internal func modelAtIndexPath(_ indexPath: IndexPath) -> Model {
+        return modelAtPath(treePathFromIndexPath(indexPath))
+    }
+
+    internal func treePathFromIndexPath(_ path: IndexPath) -> TreePath {
+        var path = path
+        var result = TreePath()
+        var node = self
+        while !path.isEmpty {
+            let nextIndex = path.removeFirst()
+            let nextModelId = node.modelCollection.models[nextIndex].modelId
+            result = result.appending(nextModelId)
+            node = node.findOrCreateNode(TreePath(components: [nextModelId]))
+        }
+        return result
+    }
+
+    internal func pathForChild(_ index: Int, of parent: TreePath?) -> TreePath {
+        let parentPath = parent ?? TreePath()
+        let modelId = modelIdForChild(path: parentPath, child: index)
+        return parentPath.appending(modelId)
+    }
+
+    internal func modelIdForChild(path: TreePath?, child index: Int) -> ModelId {
+        return findOrCreateNode(path ?? TreePath()).modelCollection.models[index].modelId
+    }
+
+    // MARK: Equatable
+
+    static func ==(lhs: NestedModelCollectionTreeController, rhs: NestedModelCollectionTreeController) -> Bool {
+        return lhs.indexPath == rhs.indexPath && lhs.modelCollection.collectionId == rhs.modelCollection.collectionId
+    }
 
     // MARK: Observable
 
@@ -78,14 +158,27 @@ internal final class NestedModelCollectionTreeController: ProxyingObservable {
 
     // MARK: Private
 
+    private weak var parent: NestedModelCollectionTreeController? = nil
     private let modelId: ModelId?
     private var childrenCache = [ModelId: NestedModelCollectionTreeController]()
+    private var modelCollectionCache = [ModelId: (Int, Model)]()
     private let modelCollection: NestedModelCollection
     private var modelCollectionObserver: Observer?
     private var diffEngine = DiffEngine()
 
+    private var indexPath: IndexPath {
+        guard let parent = parent, let modelId = modelId else { return IndexPath() }
+        guard let index = parent.modelCollectionCache[modelId]?.0 else {
+            Log.fatal(message: "Parent of model collection no longer knows about child")
+        }
+        return parent.indexPath.appending(index)
+    }
+
     private func handleCollectionEvent(_ event: CollectionEvent) {
         guard case .didChangeState(let state) = event else { return }
+
+        recreateModelCollectionCache()
+
         let indexPath = self.indexPath
         let changes = diffEngine.update([state.models])
         guard changes.hasUpdates else { return }
@@ -106,25 +199,32 @@ internal final class NestedModelCollectionTreeController: ProxyingObservable {
         observers.notify(event)
     }
 
-    private func findOrCreateNode(_ path: IndexPath) -> NestedModelCollectionTreeController {
-        guard !path.isEmpty else { return self }
-        let model = modelCollection.models[path[0]]
-        if let cached = childrenCache[model.modelId] {
+    private func findOrCreateNode(_ path: TreePath) -> NestedModelCollectionTreeController {
+        guard !path.components.isEmpty else { return self }
+        let modelId = path.components[0]
+        if let cached = childrenCache[modelId] {
             return cached.findOrCreateNode(path.dropFirst())
         } else {
+            guard let model = modelCollectionCache[modelId]?.1 else {
+                Log.fatal(message: "Attempted to fetch node for missing leaf")
+            }
             let childModelCollection = modelCollection.childModelCollection(for: model)
             let node = NestedModelCollectionTreeController(
                 modelCollection: childModelCollection,
-                modelId: model.modelId,
+                modelId: modelId,
                 parent: self)
-            childrenCache[model.modelId] = node
+            childrenCache[modelId] = node
             return node.findOrCreateNode(path.dropFirst())
         }
     }
-}
 
-extension NestedModelCollectionTreeController: Equatable {
-    static func ==(lhs: NestedModelCollectionTreeController, rhs: NestedModelCollectionTreeController) -> Bool {
-        return lhs.indexPath == rhs.indexPath && lhs.modelCollection.collectionId == rhs.modelCollection.collectionId
+    private func recreateModelCollectionCache() {
+        var modelCache = [ModelId: (Int, Model)]()
+        for (index, model) in modelCollection.models.enumerated() {
+            modelCache[model.modelId] = (index, model)
+        }
+        self.modelCollectionCache = modelCache
     }
 }
+
+extension NestedModelCollectionTreeController: Equatable {}

--- a/UI/Source/OutlineViews/mac/NestedModelCollectionTreeController.swift
+++ b/UI/Source/OutlineViews/mac/NestedModelCollectionTreeController.swift
@@ -121,7 +121,9 @@ internal final class NestedModelCollectionTreeController: ProxyingObservable {
             let nextIndex = path.removeFirst()
             let nextModelId = node.modelCollection.models[nextIndex].modelId
             result = result.appending(nextModelId)
-            node = node.findOrCreateNode(TreePath(components: [nextModelId]))
+            if !path.isEmpty {
+                node = node.findOrCreateNode(TreePath(components: [nextModelId]))
+            }
         }
         return result
     }

--- a/UI/Source/OutlineViews/mac/OutlineViewController.swift
+++ b/UI/Source/OutlineViews/mac/OutlineViewController.swift
@@ -74,8 +74,7 @@ open class OutlineViewController: ModelCollectionViewController, NSMenuDelegate,
 
     /// Access to the current view model of selected items.
     public var selectionViewModel: SelectionViewModel? {
-        let indexPaths = dataSource.indexPaths(from: outlineView.selectedRowIndexes)
-        return dataSource.selectionViewModel(for: indexPaths)
+        return dataSource.selectionViewModel(for: dataSource.paths(from: outlineView.selectedRowIndexes))
     }
 
     // MARK: NSOutlineViewDelegate

--- a/UI/Source/OutlineViews/mac/OutlineViewModelDataSource.swift
+++ b/UI/Source/OutlineViews/mac/OutlineViewModelDataSource.swift
@@ -136,7 +136,7 @@ public final class OutlineViewModelDataSource: NSObject, NSOutlineViewDataSource
 
         let removedByItem = Dictionary(grouping: event.removed, by: { $0.dropLast() as IndexPath }).filter(isVisible)
         let addedByItem = Dictionary(grouping: event.added, by: { $0.dropLast() as IndexPath }).filter(isVisible)
-        let updatedItems = event.updated.map { $0 as IndexPath }
+        let updatedItems = event.updated.map({ $0 as IndexPath }).filter({ isVisible($0.dropLast(), []) })
 
         guard !removedByItem.isEmpty || !addedByItem.isEmpty || !updatedItems.isEmpty else {
             return


### PR DESCRIPTION
Using an integer offest based approach as our item in NSOutlineViews falls apart when updates to the model collection change the index path that the model is at (ex a deletion earlier in view will result in the outline view item pointing to an address that is mismatched in the model collection)

Instead we will now use a collection of model IDs to represent the address/path of a given model within the tree which allows it to be stable across mutations that happen to its siblings.