### PR TITLE
Don’t let outline view columns resize by default 

### DIFF
--- a/UI/Source/OutlineViews/mac/OutlineViewController.swift
+++ b/UI/Source/OutlineViews/mac/OutlineViewController.swift
@@ -128,7 +128,7 @@ open class OutlineViewController:
                 outlineView.outlineTableColumn = config.column
             }
         }
-        outlineView.autoresizesOutlineColumn = true
+        outlineView.autoresizesOutlineColumn = false
         outlineView.delegate = self
         outlineView.dataSource = self
         scrollView.scrollerStyle = .overlay


### PR DESCRIPTION
When expanding nested items, don't let columns resize by default