### PR TITLE
Double click support for view model in collection view and outline view

### DIFF
--- a/Core/Source/MVVM/ViewModelBinding.swift
+++ b/Core/Source/MVVM/ViewModelBinding.swift
@@ -76,6 +76,10 @@ private struct ViewModelSelectionShim: SelectionViewModel {
 
     // MARK: ViewModelType
 
+    func actionForUserEvent(_ event: ViewModelUserEvent) -> Action? {
+        return viewModel.actionForUserEvent(event)
+    }
+
     func canHandleUserEvent(_ event: ViewModelUserEvent) -> Bool {
         return viewModel.canHandleUserEvent(event)
     }

--- a/Core/Source/MVVM/ViewModelUserEvents.swift
+++ b/Core/Source/MVVM/ViewModelUserEvents.swift
@@ -27,6 +27,9 @@ public enum ViewModelUserEvent {
 
     /// Represents the user attempting to copy the view model to the pasteboard.
     case copy
+
+    /// Represents the user double clicking a target
+    case doubleClick
 }
 
 /// Simple wrapper around NSEvent.ModifierFlags to avoid importing AppKit.
@@ -74,6 +77,8 @@ extension ViewModelUserEvent: Hashable {
             return 1<<4
         case .copy:
             return 1<<5
+        case .doubleClick:
+            return 1<<6
         }
     }
 

--- a/UI/Source/CollectionViews/mac/CollectionViewController.swift
+++ b/UI/Source/CollectionViews/mac/CollectionViewController.swift
@@ -115,6 +115,12 @@ open class CollectionViewController: ModelCollectionViewController, CollectionVi
         }
 
         scrollView.scrollerStyle = .overlay
+
+        let recognizer = NSClickGestureRecognizer(target: self, action: #selector(doubleClick(_:)))
+        recognizer.numberOfClicksRequired = 2
+        // Don't delay single-click waiting for double-click failure.
+        recognizer.delaysPrimaryMouseButtonEvents = false
+        collectionView.addGestureRecognizer(recognizer)
     }
 
     open override func viewWillLayout() {
@@ -269,5 +275,11 @@ open class CollectionViewController: ModelCollectionViewController, CollectionVi
     @objc
     private func copy(_ sender: Any) {
         selectedViewModel()?.handleUserEvent(.copy)
+    }
+
+    @objc
+    private func doubleClick(_ sender: Any) {
+        guard let action = selectionViewModel?.actionForUserEvent(.doubleClick) else { return }
+        action.send(from: context)
     }
 }

--- a/UI/Source/OutlineViews/mac/OutlineViewController.swift
+++ b/UI/Source/OutlineViews/mac/OutlineViewController.swift
@@ -133,9 +133,18 @@ open class OutlineViewController:
         outlineView.dataSource = self
         scrollView.scrollerStyle = .overlay
         dataSource.outlineView = outlineView
+
+        outlineView.target = self
+        outlineView.doubleAction = #selector(doubleClick(_:))
     }
 
     private let columnConfigs: [OutlineColumnConfig]
+
+    @objc
+    private func doubleClick(_ sender: AnyObject) {
+        guard let action = selectionViewModel?.actionForUserEvent(.doubleClick) else { return }
+        action.send(from: context)
+    }
 }
 
 private final class OutlineView: NSOutlineView {


### PR DESCRIPTION
Allows new ViewModelUserEvent .doubleClick support for collection view and outline view whenever a user double clicks on a selected item