### PR TITLE
Implement move updates for OutlineView

### DIFF
--- a/UI/Source/OutlineViews/mac/NestedModelCollectionTreeController.swift
+++ b/UI/Source/OutlineViews/mac/NestedModelCollectionTreeController.swift
@@ -159,6 +159,7 @@ internal final class NestedModelCollectionTreeController: ProxyingObservable {
         var removed: [IndexPath]
         var added: [IndexPath]
         var updated: [IndexPath]
+        var moved: [MovedModel]
     }
 
     public final var proxiedObservable: GenericObservable<Event> { return observers }
@@ -199,11 +200,17 @@ internal final class NestedModelCollectionTreeController: ProxyingObservable {
         let removedIndexPaths = changes.removedModelPaths.map {
             indexPath.appending($0.itemIndex)
         }
+        let movedPaths = changes.movedModelPaths
+
         let modelIds = Set(modelCollection.models.map({ $0.modelId }))
         childrenCache = childrenCache.filter {
             modelIds.contains($0.key)
         }
-        let event = Event(removed: removedIndexPaths, added: addedIndexPaths, updated: updatedIndexPaths)
+        let event = Event(
+            removed: removedIndexPaths,
+            added: addedIndexPaths,
+            updated: updatedIndexPaths,
+            moved: movedPaths)
         observers.notify(event)
     }
 

--- a/UI/Source/OutlineViews/mac/OutlineViewModelDataSource.swift
+++ b/UI/Source/OutlineViews/mac/OutlineViewModelDataSource.swift
@@ -157,8 +157,9 @@ public final class OutlineViewModelDataSource: NSObject, NSOutlineViewDataSource
         let removedByItem = Dictionary(grouping: event.removed, by: { $0.dropLast() as IndexPath }).filter(isVisible)
         let addedByItem = Dictionary(grouping: event.added, by: { $0.dropLast() as IndexPath }).filter(isVisible)
         let updatedItems = event.updated.map({ $0 as IndexPath }).filter({ isVisible($0.dropLast(), []) })
+        let movedItems = event.moved
 
-        guard !removedByItem.isEmpty || !addedByItem.isEmpty || !updatedItems.isEmpty else {
+        guard !removedByItem.isEmpty || !addedByItem.isEmpty || !updatedItems.isEmpty || !movedItems.isEmpty else {
             return
         }
 
@@ -198,6 +199,14 @@ public final class OutlineViewModelDataSource: NSObject, NSOutlineViewDataSource
 
         for updated in updatedItems {
             outlineView.reloadItem(treeController.treePathFromIndexPath(updated))
+        }
+
+        // The moveItem(at:inParent:to:inParent:) api doesn't seem to do what we want as it doesn't do a batch update on a
+        // static version list of the list. For example if you have one item, it will move that item then the next move will occur
+        // on the updated version. reloadItem(_:) also doesn't seem to fully work for our purposes. We can try to look into this a
+        // little bit further to improve it, but as a temporary workaround, just call reloadData any time we move items.
+        if !movedItems.isEmpty {
+            outlineView.reloadData()
         }
 
         outlineView.endUpdates()

--- a/UI/Source/OutlineViews/mac/OutlineViewModelDataSource.swift
+++ b/UI/Source/OutlineViews/mac/OutlineViewModelDataSource.swift
@@ -163,6 +163,15 @@ public final class OutlineViewModelDataSource: NSObject, NSOutlineViewDataSource
             return
         }
 
+        // The moveItem(at:inParent:to:inParent:) api doesn't seem to do what we want as it doesn't do a batch update on a
+        // static version list of the list. For example if you have one item, it will move that item then the next move will occur
+        // on the updated version. reloadItem(_:) also doesn't seem to fully work for our purposes. We can try to look into this a
+        // little bit further to improve it, but as a temporary workaround, just call reloadData any time we move items.
+        if !movedItems.isEmpty {
+            outlineView.reloadData()
+            return
+        }
+
         // TODO:(danielh) Configuaration options for animations.
         let options = NSTableView.AnimationOptions.effectFade
 
@@ -199,14 +208,6 @@ public final class OutlineViewModelDataSource: NSObject, NSOutlineViewDataSource
 
         for updated in updatedItems {
             outlineView.reloadItem(treeController.treePathFromIndexPath(updated))
-        }
-
-        // The moveItem(at:inParent:to:inParent:) api doesn't seem to do what we want as it doesn't do a batch update on a
-        // static version list of the list. For example if you have one item, it will move that item then the next move will occur
-        // on the updated version. reloadItem(_:) also doesn't seem to fully work for our purposes. We can try to look into this a
-        // little bit further to improve it, but as a temporary workaround, just call reloadData any time we move items.
-        if !movedItems.isEmpty {
-            outlineView.reloadData()
         }
 
         outlineView.endUpdates()


### PR DESCRIPTION
Call reloadData as a temporary (maybe can do better) workaround whenever there are item move updates in the OutlineView