### PR TITLE
Add helper var to allow mouse down on outline view to drag window 

### DIFF
--- a/UI/Source/OutlineViews/mac/OutlineViewController.swift
+++ b/UI/Source/OutlineViews/mac/OutlineViewController.swift
@@ -77,6 +77,15 @@ open class OutlineViewController:
     public let outlineView: NSOutlineView
     public let dataSource: OutlineViewModelDataSource
 
+    /// Enables mouse down on OutlineView to drag window.
+    public var windowDragEnabled: Bool = false {
+        didSet {
+            if let outlineView = outlineView as? OutlineView {
+                outlineView.windowDragEnabled = windowDragEnabled
+            }
+        }
+    }
+
     /// Access to the current view model of selected items.
     public var selectionViewModel: SelectionViewModel? {
         return dataSource.selectionViewModel(for: dataSource.paths(from: outlineView.selectedRowIndexes))
@@ -163,5 +172,11 @@ open class OutlineViewController:
 private final class OutlineView: NSOutlineView {
     override func menu(for event: NSEvent) -> NSMenu? {
         return (delegate as? OutlineViewController)?.dataSource.outlineView(self, menuForEvent: event)
+    }
+
+    public var windowDragEnabled: Bool = false
+
+    public override var mouseDownCanMoveWindow: Bool {
+        return windowDragEnabled
     }
 }


### PR DESCRIPTION
Allow mouse down on an outline view to be able to drag the window. We have an invisible toolbar at the top that is over the outline view. This allows dragging the invisible toolbar to drag the window.