### PR TITLE
Use header path prefix to fix an issue with Buck in Xcode

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -87,6 +87,7 @@ pilotui_shared_srcs = [
 apple_library(
     name = 'PilotUI-iOS',
     module_name = 'PilotUI',
+    header_path_prefix = 'PilotUI',
     swift_version = '4.2',
     srcs =  pilotui_shared_srcs + 
             [


### PR DESCRIPTION
When a Buck project is built with Xcode, it uses the `header_path_prefix` as module name, instead of `module_name`. Temporarily resolve the issue by adding a `header_path_prefix`.