### PR TITLE
Fix-up incorrect sample configs

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -200,9 +200,7 @@ apple_library(
     deps = [
         ':Pilot',
     ],
-    configs = {
-        "SKIP_INSTALL": "YES",
-    },
+    configs = library_configs,
     frameworks = [
         '$SDKROOT/System/Library/Frameworks/Foundation.framework'
     ],


### PR DESCRIPTION
The catalog was missing the per-build type configs.